### PR TITLE
Fix For ACRE Errors on gear

### DIFF
--- a/CfgEventHandlers.hpp
+++ b/CfgEventHandlers.hpp
@@ -1,0 +1,31 @@
+//Extended Event Handlers:
+
+class Extended_InitPost_EventHandlers {
+  class CAManBase {
+    class F_AssignGear { init = "[F_fnc_assignGearMan, _this] call ace_common_fnc_runAfterSettingsInit;"; };
+    class F_ServerGroupID { serverinit = "_this call F_Markers_fnc_serverSetupGroupID;"; };
+    class F_FixFriendlyFire { init = "if (local (_this select 0)) then {(_this select 0) addRating 100000;};";};
+  };
+  class Car {
+    class F_NoBitchZone { init = "(_this select 0) allowCrewInImmobile true;"; };
+    class F_DisableThermals { init = "(_this select 0) disableTIEquipment true;"; };
+    class F_AssignVehicleGear { serverInit  = "[(_this select 0), 'Car'] call F_fnc_assignGearVehicle;"; };
+  };
+  class Tank {
+    class F_NoBitchZone { init = "(_this select 0) allowCrewInImmobile true;"; };
+    class F_DisableThermals { init = "(_this select 0) disableTIEquipment true;"; };
+    class F_AssignVehicleGear { serverInit  = "[(_this select 0), 'Tank'] call F_fnc_assignGearVehicle;"; };
+  };
+  class Helicopter {
+    class F_DisableThermals { init = "(_this select 0) disableTIEquipment true;"; };
+    class F_AssignVehicleGear { serverInit  = "[(_this select 0), 'Helicopter'] call F_fnc_assignGearVehicle;"; };
+  };
+  class Plane {
+    class F_DisableThermals { init = "(_this select 0) disableTIEquipment true;"; };
+    class F_AssignVehicleGear { serverInit  = "[(_this select 0), 'Plane'] call F_fnc_assignGearVehicle;"; };
+  };
+  class Ship_F {
+    class F_DisableThermals { init = "(_this select 0) disableTIEquipment true;"; };
+    class F_AssignVehicleGear { serverInit  = "[(_this select 0), 'Ship_F'] call F_fnc_assignGearVehicle;"; };
+  };
+};

--- a/description.ext
+++ b/description.ext
@@ -34,36 +34,7 @@ class ACE_Settings {
 #include "CfgLoadouts.hpp"
 
 //Extended Event Handlers:
-class Extended_InitPost_EventHandlers {
-  class CAManBase {
-    class F_AssignGear { init = "_this call F_fnc_assignGearMan;"; };
-    class F_ServerGroupID { serverinit = "_this call F_Markers_fnc_serverSetupGroupID;"; };
-    class F_FixFriendlyFire { init = "if (local (_this select 0)) then {(_this select 0) addRating 100000;};";};
-  };
-  class Car {
-    class F_NoBitchZone { init = "(_this select 0) allowCrewInImmobile true;"; };
-    class F_DisableThermals { init = "(_this select 0) disableTIEquipment true;"; };
-    class F_AssignVehicleGear { serverInit  = "[(_this select 0), 'Car'] call F_fnc_assignGearVehicle;"; };
-  };
-  class Tank {
-    class F_NoBitchZone { init = "(_this select 0) allowCrewInImmobile true;"; };
-    class F_DisableThermals { init = "(_this select 0) disableTIEquipment true;"; };
-    class F_AssignVehicleGear { serverInit  = "[(_this select 0), 'Tank'] call F_fnc_assignGearVehicle;"; };
-  };
-  class Helicopter {
-    class F_DisableThermals { init = "(_this select 0) disableTIEquipment true;"; };
-    class F_AssignVehicleGear { serverInit  = "[(_this select 0), 'Helicopter'] call F_fnc_assignGearVehicle;"; };
-  };
-  class Plane {
-    class F_DisableThermals { init = "(_this select 0) disableTIEquipment true;"; };
-    class F_AssignVehicleGear { serverInit  = "[(_this select 0), 'Plane'] call F_fnc_assignGearVehicle;"; };
-  };
-  class Ship_F {
-    class F_DisableThermals { init = "(_this select 0) disableTIEquipment true;"; };
-    class F_AssignVehicleGear { serverInit  = "[(_this select 0), 'Ship_F'] call F_fnc_assignGearVehicle;"; };
-  };
-};
-
+#include "CfgEventHandlers.hpp"
 
 // F3 - Debug Console
 // Credits: Please see the F3 online manual (http://www.ferstaberinde.com/f3/en/)

--- a/f/assignGear/fn_assignGearMan.sqf
+++ b/f/assignGear/fn_assignGearMan.sqf
@@ -73,12 +73,12 @@ if ((count _vests) == 0) then {
 };
 //Random Backpack:
 if ((count _backpack) == 0) then {
-  removeBackpack _unit;
+  removeBackpackGlobal _unit;
 } else {
   _toAdd = _backpack call BIS_fnc_selectRandom;
   if ((!isNil "_toAdd") && {isClass (configFile >> "CfgVehicles" >> _toAdd)}) then {
-    removeBackpack _unit;
-    _unit addBackpack _toAdd;
+    removeBackpackGlobal _unit;
+    _unit addBackpackGlobal _toAdd;
   } else {
     [_unitClassname, format ["%1 Backpack (%2) not found using default (%3)", _loadout, _toAdd, (backpack _unit)]] call F_fnc_gearErrorLogger;
   };

--- a/f/radios/fn_acreRadioSetPlayerChannels.sqf
+++ b/f/radios/fn_acreRadioSetPlayerChannels.sqf
@@ -179,7 +179,7 @@ if (!hasInterface) exitWith {};
 
   [_groupID, _languagesPlayerSpeaks, _groupFreqIndex, _groupLRFreqIndex] spawn _addSignalsBriefing;
 
-  waitUntil {[] call acre_api_fnc_isInitialized};
+  waitUntil {[player] call acre_api_fnc_isInitialized};
   diag_log text format ["[BW] - acre_api_fnc_isInitialized @ %1, setting radios", time];
 
   _radio343 = ["ACRE_PRC343"] call acre_api_fnc_getRadioByType;


### PR DESCRIPTION
Move XEH to own file to reduce clutter of desciption ext

Uses ace's `ace_common_fnc_runAfterSettingsInit` to delay gear assign, so it doesn't run in two places.

Use global versions of backpack add/remove.