### PR TITLE
Fix respawn group broadcast

### DIFF
--- a/f/respawn/fn_RespawnWaveServer.sqf
+++ b/f/respawn/fn_RespawnWaveServer.sqf
@@ -6,12 +6,14 @@
 //
 
 params ["_groupIndex", "_position", "_faction", "_selectedRespawnGroup"];
+diag_log text format ["[BWMF] RespawnWaveServer: %1", _this];
 
 // Loop through each proposed client for respawn.
 {
   _position = _position vectorAdd [1,0,0]; // do position transofmration
 
   _x params ["_rank", "_client", "_typeOfUnit"];
+  diag_log text format ["[BWMF] RespawnWaveServer: client %1, type %2", _client, _typeOfUnit];
   _leader = _forEachIndex == 0;
   [f_serverRespawnGroupCounter,
     _position,
@@ -22,21 +24,6 @@ params ["_groupIndex", "_position", "_faction", "_selectedRespawnGroup"];
     _leader,
     _groupIndex] remoteExec ["F_fnc_RespawnLocalClient", _client, false];
 
-  //Setup respawned player to die if he disconnects?
-  [f_serverRespawnPlayerCounter] spawn {
-    private["_unitName", "_unit"];
-    sleep 5;
-    _unitName = format["respawnedUnit%1",(_this select 0)];
-    waitUntil{sleep 3;!isNil _unitName};
-    _unit = missionNamespace getVariable[_unitName,objNull];
-    while{!isNull _unit} do {
-      if (!isPlayer _unit) exitWith {
-        _unit setDamage 1;
-        [_unit] join grpNull;
-      };
-      sleep 5;
-    };
-  };
   f_serverRespawnPlayerCounter = f_serverRespawnPlayerCounter + 1;
 } forEach _selectedRespawnGroup;
 

--- a/f/respawn/respawn_gui_code.sqf
+++ b/f/respawn/respawn_gui_code.sqf
@@ -286,6 +286,7 @@ fn_respawnMap_keyUp = {
       };
       hint "Group created on ground.";
 
+      diag_log text format ["[BWMF] respawn_gui_code: sending to server: %1", [var2_groupIndex, _position, var1_faction, selectedRespawnGroup]];
       [var2_groupIndex, _position, var1_faction, selectedRespawnGroup] remoteExecCall ["F_fnc_RespawnWaveServer", 2, false];
       selectedRespawnGroup = [];
 


### PR DESCRIPTION
Needs testing, hopefully fix rpt spam:

```
Subgroup O Bravo 2-1:<No leader> (0x8b2a85e0) - network ID 2:6452
 - no leader
Subgroup leader candidate was not found, NUnits() = 1, nUnits = 0
```
- `publicVariable _groupVarName;` didn't do anything as the string's var was undefined
- Make non-leaders wait for new group to be ready to avoid creating unneeded groups
- Explicitly set leader
