### PR TITLE
Slotting/MSV improvements/fixes

### DIFF
--- a/mission.sqm
+++ b/mission.sqm
@@ -8,14 +8,14 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=1909;
+		nextID=2914;
 	};
 	class Camera
 	{
-		pos[]={652.95953,196.66109,1089.0311};
-		dir[]={0.0010302537,-0.63461488,-0.77298743};
-		up[]={0.00084880972,0.77276379,-0.63468975};
-		aside[]={-1.0000937,4.7600929e-007,-0.0013336806};
+		pos[]={742.98389,75.640015,693.63306};
+		dir[]={0.079877011,-0.61600095,-0.78374487};
+		up[]={0.062467087,0.78767008,-0.61291504};
+		aside[]={-0.99489152,3.8079452e-007,-0.10139564};
 	};
 };
 binarizationWanted=1;
@@ -481,7 +481,7 @@ class CustomAttributes
 		};
 		class Attribute3
 		{
-			property="ReviveRequiredItemsFakConsumed";
+			property="ReviveMedicSpeedMultiplier";
 			expression="false";
 			class Value
 			{
@@ -491,10 +491,10 @@ class CustomAttributes
 					{
 						type[]=
 						{
-							"BOOL"
+							"SCALAR"
 						};
 					};
-					value=1;
+					value=2;
 				};
 			};
 		};
@@ -519,25 +519,6 @@ class CustomAttributes
 		};
 		class Attribute5
 		{
-			property="ReviveMedicSpeedMultiplier";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"SCALAR"
-						};
-					};
-					value=2;
-				};
-			};
-		};
-		class Attribute6
-		{
 			property="RespawnButton";
 			expression="true";
 			class Value
@@ -555,7 +536,7 @@ class CustomAttributes
 				};
 			};
 		};
-		class Attribute7
+		class Attribute6
 		{
 			property="ReviveForceRespawnDelay";
 			expression="false";
@@ -574,7 +555,7 @@ class CustomAttributes
 				};
 			};
 		};
-		class Attribute8
+		class Attribute7
 		{
 			property="ReviveBleedOutDelay";
 			expression="false";
@@ -593,7 +574,7 @@ class CustomAttributes
 				};
 			};
 		};
-		class Attribute9
+		class Attribute8
 		{
 			property="ReviveDelay";
 			expression="false";
@@ -612,7 +593,7 @@ class CustomAttributes
 				};
 			};
 		};
-		class Attribute10
+		class Attribute9
 		{
 			property="ReviveUnconsciousStateMode";
 			expression="false";
@@ -631,7 +612,7 @@ class CustomAttributes
 				};
 			};
 		};
-		class Attribute11
+		class Attribute10
 		{
 			property="ReviveRequiredItems";
 			expression="false";
@@ -650,7 +631,7 @@ class CustomAttributes
 				};
 			};
 		};
-		nAttributes=12;
+		nAttributes=11;
 	};
 	class Category2
 	{
@@ -702,7 +683,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=179;
+		items=178;
 		class Item0
 		{
 			dataType="Group";
@@ -723,7 +704,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_BLU_COY_CO";
-						description="BluFor Company Commander@Company";
+						description="BluFor Company Commander@BluFor Company";
 						isPlayer=1;
 						isPlayable=1;
 					};
@@ -941,7 +922,7 @@ class Mission
 					{
 						rank="LIEUTENANT";
 						name="UNIT_BLU_1PLT_CO";
-						description="BluFor 1 Platoon Commander@1st Platoon (Alpha, Bravo, Charlie)";
+						description="BluFor 1 Platoon Commander@BluFor 1st Platoon (Alpha, Bravo, Charlie)";
 						isPlayable=1;
 					};
 					id=71;
@@ -1096,7 +1077,7 @@ class Mission
 					{
 						rank="LIEUTENANT";
 						name="UNIT_BLU_2PLT_CO";
-						description="BluFor 2 Platoon Commander@2nd Platoon (Delta, Echo, Foxtrot)";
+						description="BluFor 2 Platoon Commander@BluFor 2nd Platoon (Delta, Echo, Foxtrot)";
 						isPlayable=1;
 					};
 					id=75;
@@ -1251,7 +1232,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_BLU_ASL_SL";
-						description="BluFor Alpha Squad Leader@Alpha Squad";
+						description="BluFor Alpha Squad Leader@BluFor Alpha Squad";
 						isPlayable=1;
 					};
 					id=79;
@@ -1391,7 +1372,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_A1_FTL";
-						description="BluFor Alpha 1 Fireteam Leader@Alpha Fireteam 1";
+						description="BluFor Alpha 1 Fireteam Leader@BluFor Alpha Fireteam 1";
 						isPlayable=1;
 					};
 					id=82;
@@ -1667,7 +1648,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_A2_FTL";
-						description="BluFor Alpha 2 Fireteam Leader@Alpha Fireteam 2";
+						description="BluFor Alpha 2 Fireteam Leader@BluFor Alpha Fireteam 2";
 						isPlayable=1;
 					};
 					id=89;
@@ -1943,7 +1924,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_BLU_BSL_SL";
-						description="BluFor Bravo Squad Leader@Bravo Squad";
+						description="BluFor Bravo Squad Leader@BluFor Bravo Squad";
 						isPlayable=1;
 					};
 					id=96;
@@ -2083,7 +2064,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_B1_FTL";
-						description="BluFor Bravo 1 Fireteam Leader@Bravo Fireteam 1";
+						description="BluFor Bravo 1 Fireteam Leader@BluFor Bravo Fireteam 1";
 						isPlayable=1;
 					};
 					id=99;
@@ -2359,7 +2340,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_B2_FTL";
-						description="BluFor Bravo 2 Fireteam Leader@Bravo Fireteam 2";
+						description="BluFor Bravo 2 Fireteam Leader@BluFor Bravo Fireteam 2";
 						isPlayable=1;
 					};
 					id=106;
@@ -2635,7 +2616,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_BLU_CSL_SL";
-						description="BluFor Charlie Squad Leader@Charlie Squad";
+						description="BluFor Charlie Squad Leader@BluFor Charlie Squad";
 						isPlayable=1;
 					};
 					id=113;
@@ -2775,7 +2756,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_C1_FTL";
-						description="BluFor Charlie 1 Fireteam Leader@Charlie Fireteam 1";
+						description="BluFor Charlie 1 Fireteam Leader@BluFor Charlie Fireteam 1";
 						isPlayable=1;
 					};
 					id=116;
@@ -3051,7 +3032,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_C2_FTL";
-						description="BluFor Charlie 2 Fireteam Leader@Charlie Fireteam 2";
+						description="BluFor Charlie 2 Fireteam Leader@BluFor Charlie Fireteam 2";
 						isPlayable=1;
 					};
 					id=123;
@@ -3327,7 +3308,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_BLU_TH1_P";
-						description="BluFor Transport Helo 1 Pilot@Heli Transport 1";
+						description="BluFor Transport Helo 1 Pilot@BluFor Heli Transport 1";
 						isPlayable=1;
 					};
 					id=130;
@@ -3482,7 +3463,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_BLU_TH2_P";
-						description="BluFor Transport Helo 2 Pilot@Heli Transport 2";
+						description="BluFor Transport Helo 2 Pilot@BluFor Heli Transport 2";
 						isPlayable=1;
 					};
 					id=135;
@@ -3637,7 +3618,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_BLU_TH3_P";
-						description="BluFor Transport Helo 3 Pilot@Heli Transport 3";
+						description="BluFor Transport Helo 3 Pilot@BluFor Heli Transport 3";
 						isPlayable=1;
 					};
 					id=140;
@@ -3792,7 +3773,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_BLU_TH4_P";
-						description="BluFor Transport Helo 4 Pilot@Heli Transport 4";
+						description="BluFor Transport Helo 4 Pilot@BluFor Heli Transport 4";
 						isPlayable=1;
 					};
 					id=145;
@@ -3947,7 +3928,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_BLU_IFV1_C";
-						description="BluFor IFV 1 Commander@IFV 1";
+						description="BluFor IFV 1 Commander@BluFor IFV 1";
 						isPlayable=1;
 					};
 					id=214;
@@ -4078,7 +4059,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_BLU_IFV2_C";
-						description="BluFor IFV 2 Commander@IFV 2";
+						description="BluFor IFV 2 Commander@BluFor IFV 2";
 						isPlayable=1;
 					};
 					id=218;
@@ -4209,7 +4190,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_BLU_IFV3_C";
-						description="BluFor IFV 3 Commander@IFV 3";
+						description="BluFor IFV 3 Commander@BluFor IFV 3";
 						isPlayable=1;
 					};
 					id=222;
@@ -4340,7 +4321,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_BLU_IFV4_C";
-						description="BluFor IFV 4 Commander@IFV 4";
+						description="BluFor IFV 4 Commander@BluFor IFV 4";
 						isPlayable=1;
 					};
 					id=226;
@@ -4471,7 +4452,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_BLU_TNK1_C";
-						description="BluFor Tank 1 Commander@Tank 1";
+						description="BluFor Tank 1 Commander@BluFor Tank 1";
 						isPlayable=1;
 					};
 					id=230;
@@ -4602,7 +4583,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_BLU_AH1_P";
-						description="BluFor Attack Helo 1 Pilot@Attack Heli 1";
+						description="BluFor Attack Helo 1 Pilot@BluFor Attack Heli 1";
 						isPlayable=1;
 					};
 					id=234;
@@ -4719,7 +4700,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_MMG1_FTL";
-						description="BluFor Medium MG Team 1 Leader@Medium MG Team 1";
+						description="BluFor Medium MG Team 1 Leader@BluFor Medium MG Team 1";
 						isPlayable=1;
 					};
 					id=429;
@@ -4849,7 +4830,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_MMG2_FTL";
-						description="BluFor Medium MG Team 2 Leader@Medium MG Team 2";
+						description="BluFor Medium MG Team 2 Leader@BluFor Medium MG Team 2";
 						isPlayable=1;
 					};
 					id=433;
@@ -4979,7 +4960,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_MAT1_FTL";
-						description="BluFor Medium AT Team 1 Leader@Medium AT Team 1";
+						description="BluFor Medium AT Team 1 Leader@BluFor Medium AT Team 1";
 						isPlayable=1;
 					};
 					id=437;
@@ -5109,7 +5090,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_MAT2_FTL";
-						description="BluFor Medium AT Team 2 Leader@Medium AT Team 2";
+						description="BluFor Medium AT Team 2 Leader@BluFor Medium AT Team 2";
 						isPlayable=1;
 					};
 					id=441;
@@ -5239,7 +5220,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_MTR1_FTL";
-						description="BluFor Mortar Team 1 Leader@Mortar Team 1";
+						description="BluFor Mortar Team 1 Leader@BluFor Mortar Team 1";
 						isPlayable=1;
 					};
 					id=445;
@@ -5369,7 +5350,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_MSAM1_FTL";
-						description="BluFor Medium SAM Team 1 Leader@Medium SAM Team 1";
+						description="BluFor Medium SAM Team 1 Leader@BluFor Medium SAM Team 1";
 						isPlayable=1;
 					};
 					id=449;
@@ -5499,7 +5480,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_WSL_SL";
-						description="BluFor Weapon Squad Leader@Weapon Squad";
+						description="BluFor Weapon Squad Leader@BluFor Weapon Squad";
 						isPlayable=1;
 					};
 					id=453;
@@ -5638,7 +5619,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_ST1_SP";
-						description="BluFor Sniper Team 1 Spotter@Sniper Team 1";
+						description="BluFor Sniper Team 1 Spotter@BluFor Sniper Team 1";
 						isPlayable=1;
 					};
 					id=456;
@@ -5750,7 +5731,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_ENG1_FTL";
-						description="BluFor Leader Explosive Specialist@Demolitions Team";
+						description="BluFor Leader Explosive Specialist@BluFor Demolitions Team";
 						isPlayable=1;
 					};
 					id=459;
@@ -5910,7 +5891,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_BLU_DSL_SL";
-						description="BluFor Delta Squad Leader@Delta Squad";
+						description="BluFor Delta Squad Leader@BluFor Delta Squad";
 						isPlayable=1;
 					};
 					id=465;
@@ -6050,7 +6031,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_D1_FTL";
-						description="BluFor Delta 1 Fireteam Leader@Delta Fireteam 1";
+						description="BluFor Delta 1 Fireteam Leader@BluFor Delta Fireteam 1";
 						isPlayable=1;
 					};
 					id=468;
@@ -6326,7 +6307,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_D2_FTL";
-						description="BluFor Delta 2 Fireteam Leader@Delta Fireteam 2";
+						description="BluFor Delta 2 Fireteam Leader@BluFor Delta Fireteam 2";
 						isPlayable=1;
 					};
 					id=475;
@@ -6602,7 +6583,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_BLU_ESL_SL";
-						description="BluFor Echo Squad Leader@Echo Squad";
+						description="BluFor Echo Squad Leader@BluFor Echo Squad";
 						isPlayable=1;
 					};
 					id=482;
@@ -6742,7 +6723,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_E1_FTL";
-						description="BluFor Echo 1 Fireteam Leader@Echo Fireteam 1";
+						description="BluFor Echo 1 Fireteam Leader@BluFor Echo Fireteam 1";
 						isPlayable=1;
 					};
 					id=485;
@@ -7018,7 +6999,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_E2_FTL";
-						description="BluFor Echo 2 Fireteam Leader@Echo Fireteam 2";
+						description="BluFor Echo 2 Fireteam Leader@BluFor Echo Fireteam 2";
 						isPlayable=1;
 					};
 					id=492;
@@ -7294,7 +7275,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_BLU_FSL_SL";
-						description="BluFor Foxtrot Squad Leader@Foxtrot Squad";
+						description="BluFor Foxtrot Squad Leader@BluFor Foxtrot Squad";
 						isPlayable=1;
 					};
 					id=499;
@@ -7434,7 +7415,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_F1_FTL";
-						description="BluFor Foxtrot 1 Fireteam Leader@Foxtrot Fireteam 1";
+						description="BluFor Foxtrot 1 Fireteam Leader@BluFor Foxtrot Fireteam 1";
 						isPlayable=1;
 					};
 					id=502;
@@ -7710,7 +7691,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_BLU_F2_FTL";
-						description="BluFor Foxtrot 2 Fireteam Leader@Foxtrot Fireteam 2";
+						description="BluFor Foxtrot 2 Fireteam Leader@BluFor Foxtrot Fireteam 2";
 						isPlayable=1;
 					};
 					id=509;
@@ -7978,14 +7959,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={647.98248,5.0014391,879.96143};
+						position[]={647.98199,5.0014391,879.961};
 					};
 					side="Civilian";
 					flags=6;
 					class Attributes
 					{
 						name="UNIT_CIV_P1_J";
-						description="Civilian Press Team 1 Journalist";
+						description="Civilian Press Team 1 Journalist@Civilian Press Team 1";
 						isPlayable=1;
 					};
 					id=682;
@@ -8051,14 +8032,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={647.95551,5.0014391,875.99146};
+						position[]={647.95599,5.0014391,875.99097};
 					};
 					side="Civilian";
 					flags=6;
 					class Attributes
 					{
 						name="UNIT_CIV_P2_J";
-						description="Civilian Press Team 2 Journalist";
+						description="Civilian Press Team 2 Journalist@Civilian Press Team 2";
 						isPlayable=1;
 					};
 					id=685;
@@ -8124,14 +8105,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={647.91748,5.0014391,871.96448};
+						position[]={647.91699,5.0014391,871.96399};
 					};
 					side="Civilian";
 					flags=6;
 					class Attributes
 					{
 						name="UNIT_CIV_P3_J";
-						description="Civilian Press Team 3 Journalist";
+						description="Civilian Press Team 3 Journalist@Civilian Press Team 3";
 						isPlayable=1;
 					};
 					id=688;
@@ -8191,8 +8172,80 @@ class Mission
 			side="Civilian";
 			class Entities
 			{
-				items=1;
+				items=6;
 				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={656,5.0014391,880.01099};
+					};
+					side="Civilian";
+					flags=6;
+					class Attributes
+					{
+						name="UNIT_CIV_C1";
+						description="Civilian Civilian 1@Civilian Civilians";
+						isPlayable=1;
+					};
+					id=695;
+					type="C_man_1";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={655.9375,5.0014391,878.02844};
+					};
+					side="Civilian";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_CIV_C2";
+						description="Civilian Civilian 2";
+						isPlayable=1;
+					};
+					id=697;
+					type="C_man_1";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={655.9505,5.0014391,875.97443};
+					};
+					side="Civilian";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_CIV_C3";
+						description="Civilian Civilian 3";
+						isPlayable=1;
+					};
+					id=699;
+					type="C_man_1";
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={655.9635,5.0014391,873.92145};
+					};
+					side="Civilian";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_CIV_C4";
+						description="Civilian Civilian 4";
+						isPlayable=1;
+					};
+					id=701;
+					type="C_man_1";
+				};
+				class Item4
 				{
 					dataType="Object";
 					class PositionInfo
@@ -8200,7 +8253,7 @@ class Mission
 						position[]={653.92053,5.0014391,879.95447};
 					};
 					side="Civilian";
-					flags=6;
+					flags=4;
 					class Attributes
 					{
 						init="this setVariable [""F_Gear"", ""CEO""];";
@@ -8211,44 +8264,7 @@ class Mission
 					id=691;
 					type="C_man_1";
 				};
-			};
-			class Attributes
-			{
-				name="GROUP_CIV_CEO1";
-			};
-			id=690;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="groupID";
-					expression="[_this, _value] call CBA_fnc_setCallsign";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="Civ CEO 1";
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item45
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
+				class Item5
 				{
 					dataType="Object";
 					class PositionInfo
@@ -8256,7 +8272,7 @@ class Mission
 						position[]={651.98553,5.0014391,879.93646};
 					};
 					side="Civilian";
-					flags=6;
+					flags=4;
 					class Attributes
 					{
 						name="UNIT_CIV_H1";
@@ -8265,61 +8281,6 @@ class Mission
 					};
 					id=693;
 					type="C_man_hunter_1_F";
-				};
-			};
-			class Attributes
-			{
-				name="GROUP_CIV_H1";
-			};
-			id=692;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="groupID";
-					expression="[_this, _value] call CBA_fnc_setCallsign";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="Civ Hunter 1";
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item46
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={656.00049,5.0014391,880.01147};
-					};
-					side="Civilian";
-					flags=6;
-					class Attributes
-					{
-						name="UNIT_CIV_C1";
-						description="Civilian Civilian 1";
-						isPlayable=1;
-					};
-					id=695;
-					type="C_man_1";
 				};
 			};
 			class Attributes
@@ -8351,172 +8312,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item47
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={655.9375,5.0014391,878.02844};
-					};
-					side="Civilian";
-					flags=6;
-					class Attributes
-					{
-						name="UNIT_CIV_C2";
-						description="Civilian Civilian 2";
-						isPlayable=1;
-					};
-					id=697;
-					type="C_man_1";
-				};
-			};
-			class Attributes
-			{
-				name="GROUP_CIV_C2";
-			};
-			id=696;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="groupID";
-					expression="[_this, _value] call CBA_fnc_setCallsign";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="Civ Civilian 2";
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item48
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={655.9505,5.0014391,875.97443};
-					};
-					side="Civilian";
-					flags=6;
-					class Attributes
-					{
-						name="UNIT_CIV_C3";
-						description="Civilian Civilian 3";
-						isPlayable=1;
-					};
-					id=699;
-					type="C_man_1";
-				};
-			};
-			class Attributes
-			{
-				name="GROUP_CIV_C3";
-			};
-			id=698;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="groupID";
-					expression="[_this, _value] call CBA_fnc_setCallsign";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="Civ Civilian 3";
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item49
-		{
-			dataType="Group";
-			side="Civilian";
-			class Entities
-			{
-				items=1;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={655.9635,5.0014391,873.92145};
-					};
-					side="Civilian";
-					flags=6;
-					class Attributes
-					{
-						name="UNIT_CIV_C4";
-						description="Civilian Civilian 4";
-						isPlayable=1;
-					};
-					id=701;
-					type="C_man_1";
-				};
-			};
-			class Attributes
-			{
-				name="GROUP_CIV_C4";
-			};
-			id=700;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="groupID";
-					expression="[_this, _value] call CBA_fnc_setCallsign";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="Civ Civilian 4";
-						};
-					};
-				};
-				nAttributes=1;
-			};
-		};
-		class Item50
+		class Item45
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8796,7 +8592,7 @@ class Mission
 				nAttributes=14;
 			};
 		};
-		class Item51
+		class Item46
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8848,7 +8644,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item52
+		class Item47
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -8938,7 +8734,7 @@ class Mission
 				nAttributes=4;
 			};
 		};
-		class Item53
+		class Item48
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9048,7 +8844,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item54
+		class Item49
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9081,7 +8877,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item55
+		class Item50
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9191,7 +8987,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item56
+		class Item51
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9301,7 +9097,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item57
+		class Item52
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9313,7 +9109,7 @@ class Mission
 			id=709;
 			type="HeadlessClient_F";
 		};
-		class Item58
+		class Item53
 		{
 			dataType="Group";
 			side="West";
@@ -9325,14 +9121,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={736.03156,5.0014391,888.0257};
+						position[]={736.03198,5.0014391,888.026};
 					};
 					side="West";
 					flags=6;
 					class Attributes
 					{
 						rank="LIEUTENANT";
-						description="JIP Offcer (CO/XO/Plt/Sgt)";
+						description="JIP Offcer (CO/XO/Plt/Sgt)@BluFor JIP Squad";
 						isPlayable=1;
 					};
 					id=667;
@@ -10065,7 +9861,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item59
+		class Item54
 		{
 			dataType="Group";
 			side="Independent";
@@ -10085,7 +9881,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_IND_COY_CO";
-						description="Indy Company Commander@Company";
+						description="Indy Company Commander@Indy Company";
 						isPlayable=1;
 					};
 					id=800;
@@ -10281,7 +10077,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item60
+		class Item55
 		{
 			dataType="Group";
 			side="Independent";
@@ -10302,7 +10098,7 @@ class Mission
 					{
 						rank="LIEUTENANT";
 						name="UNIT_IND_1PLT_CO";
-						description="Indy 1 Platoon Commander@1st Platoon (Alpha, Bravo, Charlie)";
+						description="Indy 1 Platoon Commander@Indy 1st Platoon (Alpha, Bravo, Charlie)";
 						isPlayable=1;
 					};
 					id=806;
@@ -10437,7 +10233,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item61
+		class Item56
 		{
 			dataType="Group";
 			side="Independent";
@@ -10457,7 +10253,7 @@ class Mission
 					{
 						rank="LIEUTENANT";
 						name="UNIT_IND_2PLT_CO";
-						description="Indy 2 Platoon Commander@2nd Platoon (Delta, Echo, Foxtrot)";
+						description="Indy 2 Platoon Commander@Indy 2nd Platoon (Delta, Echo, Foxtrot)";
 						isPlayable=1;
 					};
 					id=810;
@@ -10592,7 +10388,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item62
+		class Item57
 		{
 			dataType="Group";
 			side="Independent";
@@ -10612,7 +10408,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_IND_ASL_SL";
-						description="Indy Alpha Squad Leader@Alpha Squad";
+						description="Indy Alpha Squad Leader@Indy Alpha Squad";
 						isPlayable=1;
 					};
 					id=814;
@@ -10732,7 +10528,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item63
+		class Item58
 		{
 			dataType="Group";
 			side="Independent";
@@ -10752,7 +10548,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_A1_FTL";
-						description="Indy Alpha 1 Fireteam Leader@Alpha Fireteam 1";
+						description="Indy Alpha 1 Fireteam Leader@Indy Alpha Fireteam 1";
 						isPlayable=1;
 					};
 					id=817;
@@ -11008,7 +10804,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item64
+		class Item59
 		{
 			dataType="Group";
 			side="Independent";
@@ -11028,7 +10824,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_A2_FTL";
-						description="Indy Alpha 2 Fireteam Leader@Alpha Fireteam 2";
+						description="Indy Alpha 2 Fireteam Leader@Indy Alpha Fireteam 2";
 						isPlayable=1;
 					};
 					id=824;
@@ -11284,7 +11080,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item65
+		class Item60
 		{
 			dataType="Group";
 			side="Independent";
@@ -11304,7 +11100,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_IND_BSL_SL";
-						description="Indy Bravo Squad Leader@Bravo Squad";
+						description="Indy Bravo Squad Leader@Indy Bravo Squad";
 						isPlayable=1;
 					};
 					id=831;
@@ -11424,7 +11220,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item66
+		class Item61
 		{
 			dataType="Group";
 			side="Independent";
@@ -11444,7 +11240,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_B1_FTL";
-						description="Indy Bravo 1 Fireteam Leader@Bravo Fireteam 1";
+						description="Indy Bravo 1 Fireteam Leader@Indy Bravo Fireteam 1";
 						isPlayable=1;
 					};
 					id=834;
@@ -11700,7 +11496,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item67
+		class Item62
 		{
 			dataType="Group";
 			side="Independent";
@@ -11720,7 +11516,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_B2_FTL";
-						description="Indy Bravo 2 Fireteam Leader@Bravo Fireteam 2";
+						description="Indy Bravo 2 Fireteam Leader@Indy Bravo Fireteam 2";
 						isPlayable=1;
 					};
 					id=841;
@@ -11976,7 +11772,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item68
+		class Item63
 		{
 			dataType="Group";
 			side="Independent";
@@ -11996,7 +11792,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_IND_CSL_SL";
-						description="Indy Charlie Squad Leader@Charlie Squad";
+						description="Indy Charlie Squad Leader@Indy Charlie Squad";
 						isPlayable=1;
 					};
 					id=848;
@@ -12116,7 +11912,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item69
+		class Item64
 		{
 			dataType="Group";
 			side="Independent";
@@ -12136,7 +11932,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_C1_FTL";
-						description="Indy Charlie 1 Fireteam Leader@Charlie Fireteam 1";
+						description="Indy Charlie 1 Fireteam Leader@Indy Charlie Fireteam 1";
 						isPlayable=1;
 					};
 					id=851;
@@ -12392,7 +12188,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item70
+		class Item65
 		{
 			dataType="Group";
 			side="Independent";
@@ -12412,7 +12208,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_C2_FTL";
-						description="Indy Charlie 2 Fireteam Leader@Charlie Fireteam 2";
+						description="Indy Charlie 2 Fireteam Leader@Indy Charlie Fireteam 2";
 						isPlayable=1;
 					};
 					id=858;
@@ -12668,7 +12464,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item71
+		class Item66
 		{
 			dataType="Group";
 			side="Independent";
@@ -12688,7 +12484,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_IND_TH1_P";
-						description="Indy Transport Helo 1 Pilot@Heli Transport 1";
+						description="Indy Transport Helo 1 Pilot@Indy Heli Transport 1";
 						isPlayable=1;
 					};
 					id=865;
@@ -12823,7 +12619,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item72
+		class Item67
 		{
 			dataType="Group";
 			side="Independent";
@@ -12843,7 +12639,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_IND_TH2_P";
-						description="Indy Transport Helo 2 Pilot@Heli Transport 2";
+						description="Indy Transport Helo 2 Pilot@Indy Heli Transport 2";
 						isPlayable=1;
 					};
 					id=870;
@@ -12978,7 +12774,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item73
+		class Item68
 		{
 			dataType="Group";
 			side="Independent";
@@ -12998,7 +12794,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_IND_TH3_P";
-						description="Indy Transport Helo 3 Pilot@Heli Transport 3";
+						description="Indy Transport Helo 3 Pilot@Indy Heli Transport 3";
 						isPlayable=1;
 					};
 					id=875;
@@ -13133,7 +12929,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item74
+		class Item69
 		{
 			dataType="Group";
 			side="Independent";
@@ -13153,7 +12949,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_IND_TH4_P";
-						description="Indy Transport Helo 4 Pilot@Heli Transport 4";
+						description="Indy Transport Helo 4 Pilot@Indy Heli Transport 4";
 						isPlayable=1;
 					};
 					id=880;
@@ -13288,7 +13084,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item75
+		class Item70
 		{
 			dataType="Group";
 			side="Independent";
@@ -13308,7 +13104,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_IND_IFV1_C";
-						description="Indy IFV 1 Commander@IFV 1";
+						description="Indy IFV 1 Commander@Indy IFV 1";
 						isPlayable=1;
 					};
 					id=885;
@@ -13419,7 +13215,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item76
+		class Item71
 		{
 			dataType="Group";
 			side="Independent";
@@ -13439,7 +13235,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_IND_IFV2_C";
-						description="Indy IFV 2 Commander@IFV 2";
+						description="Indy IFV 2 Commander@Indy IFV 2";
 						isPlayable=1;
 					};
 					id=889;
@@ -13550,7 +13346,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item77
+		class Item72
 		{
 			dataType="Group";
 			side="Independent";
@@ -13570,7 +13366,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_IND_IFV3_C";
-						description="Indy IFV 3 Commander@IFV 3";
+						description="Indy IFV 3 Commander@Indy IFV 3";
 						isPlayable=1;
 					};
 					id=893;
@@ -13681,7 +13477,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item78
+		class Item73
 		{
 			dataType="Group";
 			side="Independent";
@@ -13701,7 +13497,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_IND_IFV4_C";
-						description="Indy IFV 4 Commander@IFV 4";
+						description="Indy IFV 4 Commander@Indy IFV 4";
 						isPlayable=1;
 					};
 					id=897;
@@ -13812,7 +13608,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item79
+		class Item74
 		{
 			dataType="Group";
 			side="Independent";
@@ -13832,7 +13628,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_IND_TNK1_C";
-						description="Indy Tank 1 Commander@Tank 1";
+						description="Indy Tank 1 Commander@Indy Tank 1";
 						isPlayable=1;
 					};
 					id=901;
@@ -13943,7 +13739,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item80
+		class Item75
 		{
 			dataType="Group";
 			side="Independent";
@@ -13963,7 +13759,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_IND_AH1_P";
-						description="Indy Attack Helo 1 Pilot@Attack Heli 1";
+						description="Indy Attack Helo 1 Pilot@Indy Attack Heli 1";
 						isPlayable=1;
 					};
 					id=905;
@@ -14060,7 +13856,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item81
+		class Item76
 		{
 			dataType="Group";
 			side="Independent";
@@ -14080,7 +13876,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_MMG1_FTL";
-						description="Indy Medium MG Team 1 Leader@Medium MG Team 1";
+						description="Indy Medium MG Team 1 Leader@Indy Medium MG Team 1";
 						isPlayable=1;
 					};
 					id=908;
@@ -14190,7 +13986,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item82
+		class Item77
 		{
 			dataType="Group";
 			side="Independent";
@@ -14210,7 +14006,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_MMG2_FTL";
-						description="Indy Medium MG Team 2 Leader@Medium MG Team 2";
+						description="Indy Medium MG Team 2 Leader@Indy Medium MG Team 2";
 						isPlayable=1;
 					};
 					id=912;
@@ -14320,7 +14116,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item83
+		class Item78
 		{
 			dataType="Group";
 			side="Independent";
@@ -14340,7 +14136,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_MAT1_FTL";
-						description="Indy Medium AT Team 1 Leader@Medium AT Team 1";
+						description="Indy Medium AT Team 1 Leader@Indy Medium AT Team 1";
 						isPlayable=1;
 					};
 					id=916;
@@ -14450,7 +14246,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item84
+		class Item79
 		{
 			dataType="Group";
 			side="Independent";
@@ -14470,7 +14266,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_MAT2_FTL";
-						description="Indy Medium AT Team 2 Leader@Medium AT Team 2";
+						description="Indy Medium AT Team 2 Leader@Indy Medium AT Team 2";
 						isPlayable=1;
 					};
 					id=920;
@@ -14580,7 +14376,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item85
+		class Item80
 		{
 			dataType="Group";
 			side="Independent";
@@ -14600,7 +14396,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_MTR1_FTL";
-						description="Indy Mortar Team 1 Leader@Mortar Team 1";
+						description="Indy Mortar Team 1 Leader@Indy Mortar Team 1";
 						isPlayable=1;
 					};
 					id=924;
@@ -14710,7 +14506,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item86
+		class Item81
 		{
 			dataType="Group";
 			side="Independent";
@@ -14730,7 +14526,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_MSAM1_FTL";
-						description="Indy Medium SAM Team 1 Leader@Medium SAM Team 1";
+						description="Indy Medium SAM Team 1 Leader@Indy Medium SAM Team 1";
 						isPlayable=1;
 					};
 					id=928;
@@ -14840,7 +14636,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item87
+		class Item82
 		{
 			dataType="Group";
 			side="Independent";
@@ -14860,7 +14656,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_WSL_SL";
-						description="Indy Weapon Squad Leader@Weapon Squad";
+						description="Indy Weapon Squad Leader@Indy Weapon Squad";
 						isPlayable=1;
 					};
 					id=932;
@@ -14979,7 +14775,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item88
+		class Item83
 		{
 			dataType="Group";
 			side="Independent";
@@ -14999,7 +14795,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_ST1_SP";
-						description="Indy Sniper Team 1 Spotter@Sniper Team 1";
+						description="Indy Sniper Team 1 Spotter@Indy Sniper Team 1";
 						isPlayable=1;
 					};
 					id=935;
@@ -15091,7 +14887,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item89
+		class Item84
 		{
 			dataType="Group";
 			side="Independent";
@@ -15111,7 +14907,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_ENG1_FTL";
-						description="Indy Leader Explosive Specialist@Demolitions Team";
+						description="Indy Leader Explosive Specialist@Indy Demolitions Team";
 						isPlayable=1;
 					};
 					id=938;
@@ -15239,7 +15035,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item90
+		class Item85
 		{
 			dataType="Group";
 			side="Independent";
@@ -15259,7 +15055,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_IND_DSL_SL";
-						description="Indy Delta Squad Leader@Delta Squad";
+						description="Indy Delta Squad Leader@Indy Delta Squad";
 						isPlayable=1;
 					};
 					id=943;
@@ -15379,7 +15175,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item91
+		class Item86
 		{
 			dataType="Group";
 			side="Independent";
@@ -15399,7 +15195,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_D1_FTL";
-						description="Indy Delta 1 Fireteam Leader@Delta Fireteam 1";
+						description="Indy Delta 1 Fireteam Leader@Indy Delta Fireteam 1";
 						isPlayable=1;
 					};
 					id=946;
@@ -15655,7 +15451,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item92
+		class Item87
 		{
 			dataType="Group";
 			side="Independent";
@@ -15675,7 +15471,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_D2_FTL";
-						description="Indy Delta 2 Fireteam Leader@Delta Fireteam 2";
+						description="Indy Delta 2 Fireteam Leader@Indy Delta Fireteam 2";
 						isPlayable=1;
 					};
 					id=953;
@@ -15931,7 +15727,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item93
+		class Item88
 		{
 			dataType="Group";
 			side="Independent";
@@ -15951,7 +15747,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_IND_ESL_SL";
-						description="Indy Echo Squad Leader@Echo Squad";
+						description="Indy Echo Squad Leader@Indy Echo Squad";
 						isPlayable=1;
 					};
 					id=960;
@@ -16071,7 +15867,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item94
+		class Item89
 		{
 			dataType="Group";
 			side="Independent";
@@ -16091,7 +15887,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_E1_FTL";
-						description="Indy Echo 1 Fireteam Leader@Echo Fireteam 1";
+						description="Indy Echo 1 Fireteam Leader@Indy Echo Fireteam 1";
 						isPlayable=1;
 					};
 					id=963;
@@ -16347,7 +16143,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item95
+		class Item90
 		{
 			dataType="Group";
 			side="Independent";
@@ -16367,7 +16163,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_E2_FTL";
-						description="Indy Echo 2 Fireteam Leader@Echo Fireteam 2";
+						description="Indy Echo 2 Fireteam Leader@Indy Echo Fireteam 2";
 						isPlayable=1;
 					};
 					id=970;
@@ -16623,7 +16419,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item96
+		class Item91
 		{
 			dataType="Group";
 			side="Independent";
@@ -16643,7 +16439,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_IND_FSL_SL";
-						description="Indy Foxtrot Squad Leader@Foxtrot Squad";
+						description="Indy Foxtrot Squad Leader@Indy Foxtrot Squad";
 						isPlayable=1;
 					};
 					id=977;
@@ -16763,7 +16559,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item97
+		class Item92
 		{
 			dataType="Group";
 			side="Independent";
@@ -16783,7 +16579,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_F1_FTL";
-						description="Indy Foxtrot 1 Fireteam Leader@Foxtrot Fireteam 1";
+						description="Indy Foxtrot 1 Fireteam Leader@Indy Foxtrot Fireteam 1";
 						isPlayable=1;
 					};
 					id=980;
@@ -17039,7 +16835,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item98
+		class Item93
 		{
 			dataType="Group";
 			side="Independent";
@@ -17059,7 +16855,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_IND_F2_FTL";
-						description="Indy Foxtrot 2 Fireteam Leader@Foxtrot Fireteam 2";
+						description="Indy Foxtrot 2 Fireteam Leader@Indy Foxtrot Fireteam 2";
 						isPlayable=1;
 					};
 					id=987;
@@ -17315,7 +17111,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item99
+		class Item94
 		{
 			dataType="Group";
 			side="Independent";
@@ -17327,14 +17123,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={544.00262,5.0014391,887.98669};
+						position[]={544.00299,5.0014391,887.987};
 					};
 					side="Independent";
 					flags=6;
 					class Attributes
 					{
 						rank="LIEUTENANT";
-						description="JIP Offcer (CO/XO/Plt/Sgt)";
+						description="JIP Offcer (CO/XO/Plt/Sgt)@Indy JIP Squad";
 						isPlayable=1;
 					};
 					id=999;
@@ -18067,7 +17863,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item100
+		class Item95
 		{
 			dataType="Group";
 			side="East";
@@ -18087,7 +17883,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_OPF_COY_CO";
-						description="OpFor Company Commander@Company";
+						description="OpFor Company Commander@OpFor Company";
 						isPlayable=1;
 					};
 					id=1053;
@@ -18283,7 +18079,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item101
+		class Item96
 		{
 			dataType="Group";
 			side="East";
@@ -18304,7 +18100,7 @@ class Mission
 					{
 						rank="LIEUTENANT";
 						name="UNIT_OPF_1PLT_CO";
-						description="OpFor 1 Platoon Commander@1st Platoon (Alpha, Bravo, Charlie)";
+						description="OpFor 1 Platoon Commander@OpFor 1st Platoon (Alpha, Bravo, Charlie)";
 						isPlayable=1;
 					};
 					id=1059;
@@ -18439,7 +18235,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item102
+		class Item97
 		{
 			dataType="Group";
 			side="East";
@@ -18459,7 +18255,7 @@ class Mission
 					{
 						rank="LIEUTENANT";
 						name="UNIT_OPF_2PLT_CO";
-						description="OpFor 2 Platoon Commander@2nd Platoon (Delta, Echo, Foxtrot)";
+						description="OpFor 2 Platoon Commander@OpFor 2nd Platoon (Delta, Echo, Foxtrot)";
 						isPlayable=1;
 					};
 					id=1063;
@@ -18594,7 +18390,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item103
+		class Item98
 		{
 			dataType="Group";
 			side="East";
@@ -18614,7 +18410,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_OPF_ASL_SL";
-						description="OpFor Alpha Squad Leader@Alpha Squad";
+						description="OpFor Alpha Squad Leader@OpFor Alpha Squad";
 						isPlayable=1;
 					};
 					id=1067;
@@ -18734,7 +18530,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item104
+		class Item99
 		{
 			dataType="Group";
 			side="East";
@@ -18754,7 +18550,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_A1_FTL";
-						description="OpFor Alpha 1 Fireteam Leader@Alpha Fireteam 1";
+						description="OpFor Alpha 1 Fireteam Leader@OpFor Alpha Fireteam 1";
 						isPlayable=1;
 					};
 					id=1070;
@@ -19010,7 +18806,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item105
+		class Item100
 		{
 			dataType="Group";
 			side="East";
@@ -19030,7 +18826,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_A2_FTL";
-						description="OpFor Alpha 2 Fireteam Leader@Alpha Fireteam 2";
+						description="OpFor Alpha 2 Fireteam Leader@OpFor Alpha Fireteam 2";
 						isPlayable=1;
 					};
 					id=1077;
@@ -19286,7 +19082,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item106
+		class Item101
 		{
 			dataType="Group";
 			side="East";
@@ -19306,7 +19102,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_OPF_BSL_SL";
-						description="OpFor Bravo Squad Leader@Bravo Squad";
+						description="OpFor Bravo Squad Leader@OpFor Bravo Squad";
 						isPlayable=1;
 					};
 					id=1084;
@@ -19426,7 +19222,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item107
+		class Item102
 		{
 			dataType="Group";
 			side="East";
@@ -19446,7 +19242,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_B1_FTL";
-						description="OpFor Bravo 1 Fireteam Leader@Bravo Fireteam 1";
+						description="OpFor Bravo 1 Fireteam Leader@OpFor Bravo Fireteam 1";
 						isPlayable=1;
 					};
 					id=1087;
@@ -19702,7 +19498,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item108
+		class Item103
 		{
 			dataType="Group";
 			side="East";
@@ -19722,7 +19518,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_B2_FTL";
-						description="OpFor Bravo 2 Fireteam Leader@Bravo Fireteam 2";
+						description="OpFor Bravo 2 Fireteam Leader@OpFor Bravo Fireteam 2";
 						isPlayable=1;
 					};
 					id=1094;
@@ -19978,7 +19774,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item109
+		class Item104
 		{
 			dataType="Group";
 			side="East";
@@ -19998,7 +19794,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_OPF_CSL_SL";
-						description="OpFor Charlie Squad Leader@Charlie Squad";
+						description="OpFor Charlie Squad Leader@OpFor Charlie Squad";
 						isPlayable=1;
 					};
 					id=1101;
@@ -20118,7 +19914,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item110
+		class Item105
 		{
 			dataType="Group";
 			side="East";
@@ -20138,7 +19934,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_C1_FTL";
-						description="OpFor Charlie 1 Fireteam Leader@Charlie Fireteam 1";
+						description="OpFor Charlie 1 Fireteam Leader@OpFor Charlie Fireteam 1";
 						isPlayable=1;
 					};
 					id=1104;
@@ -20394,7 +20190,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item111
+		class Item106
 		{
 			dataType="Group";
 			side="East";
@@ -20414,7 +20210,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_C2_FTL";
-						description="OpFor Charlie 2 Fireteam Leader@Charlie Fireteam 2";
+						description="OpFor Charlie 2 Fireteam Leader@OpFor Charlie Fireteam 2";
 						isPlayable=1;
 					};
 					id=1111;
@@ -20670,7 +20466,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item112
+		class Item107
 		{
 			dataType="Group";
 			side="East";
@@ -20690,7 +20486,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_OPF_TH1_P";
-						description="OpFor Transport Helo 1 Pilot@Heli Transport 1";
+						description="OpFor Transport Helo 1 Pilot@OpFor Heli Transport 1";
 						isPlayable=1;
 					};
 					id=1118;
@@ -20825,7 +20621,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item113
+		class Item108
 		{
 			dataType="Group";
 			side="East";
@@ -20845,7 +20641,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_OPF_TH2_P";
-						description="OpFor Transport Helo 2 Pilot@Heli Transport 2";
+						description="OpFor Transport Helo 2 Pilot@OpFor Heli Transport 2";
 						isPlayable=1;
 					};
 					id=1123;
@@ -20980,7 +20776,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item114
+		class Item109
 		{
 			dataType="Group";
 			side="East";
@@ -21000,7 +20796,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_OPF_TH3_P";
-						description="OpFor Transport Helo 3 Pilot@Heli Transport 3";
+						description="OpFor Transport Helo 3 Pilot@OpFor Heli Transport 3";
 						isPlayable=1;
 					};
 					id=1128;
@@ -21135,7 +20931,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item115
+		class Item110
 		{
 			dataType="Group";
 			side="East";
@@ -21155,7 +20951,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_OPF_TH4_P";
-						description="OpFor Transport Helo 4 Pilot@Heli Transport 4";
+						description="OpFor Transport Helo 4 Pilot@OpFor Heli Transport 4";
 						isPlayable=1;
 					};
 					id=1133;
@@ -21290,7 +21086,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item116
+		class Item111
 		{
 			dataType="Group";
 			side="East";
@@ -21310,7 +21106,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_OPF_IFV1_C";
-						description="OpFor IFV 1 Commander@IFV 1";
+						description="OpFor IFV 1 Commander@OpFor IFV 1";
 						isPlayable=1;
 					};
 					id=1138;
@@ -21421,7 +21217,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item117
+		class Item112
 		{
 			dataType="Group";
 			side="East";
@@ -21441,7 +21237,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_OPF_IFV2_C";
-						description="OpFor IFV 2 Commander@IFV 2";
+						description="OpFor IFV 2 Commander@OpFor IFV 2";
 						isPlayable=1;
 					};
 					id=1142;
@@ -21552,7 +21348,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item118
+		class Item113
 		{
 			dataType="Group";
 			side="East";
@@ -21572,7 +21368,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_OPF_IFV3_C";
-						description="OpFor IFV 3 Commander@IFV 3";
+						description="OpFor IFV 3 Commander@OpFor IFV 3";
 						isPlayable=1;
 					};
 					id=1146;
@@ -21683,7 +21479,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item119
+		class Item114
 		{
 			dataType="Group";
 			side="East";
@@ -21703,7 +21499,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_OPF_IFV4_C";
-						description="OpFor IFV 4 Commander@IFV 4";
+						description="OpFor IFV 4 Commander@OpFor IFV 4";
 						isPlayable=1;
 					};
 					id=1150;
@@ -21814,7 +21610,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item120
+		class Item115
 		{
 			dataType="Group";
 			side="East";
@@ -21834,7 +21630,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_OPF_TNK1_C";
-						description="OpFor Tank 1 Commander@Tank 1";
+						description="OpFor Tank 1 Commander@OpFor Tank 1";
 						isPlayable=1;
 					};
 					id=1154;
@@ -21945,7 +21741,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item121
+		class Item116
 		{
 			dataType="Group";
 			side="East";
@@ -21965,7 +21761,7 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_OPF_AH1_P";
-						description="OpFor Attack Helo 1 Pilot@Attack Heli 1";
+						description="OpFor Attack Helo 1 Pilot@OpFor Attack Heli 1";
 						isPlayable=1;
 					};
 					id=1158;
@@ -22062,7 +21858,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item122
+		class Item117
 		{
 			dataType="Group";
 			side="East";
@@ -22082,7 +21878,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_MMG1_FTL";
-						description="OpFor Medium MG Team 1 Leader@Medium MG Team 1";
+						description="OpFor Medium MG Team 1 Leader@OpFor Medium MG Team 1";
 						isPlayable=1;
 					};
 					id=1161;
@@ -22192,7 +21988,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item123
+		class Item118
 		{
 			dataType="Group";
 			side="East";
@@ -22212,7 +22008,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_MMG2_FTL";
-						description="OpFor Medium MG Team 2 Leader@Medium MG Team 2";
+						description="OpFor Medium MG Team 2 Leader@OpFor Medium MG Team 2";
 						isPlayable=1;
 					};
 					id=1165;
@@ -22322,7 +22118,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item124
+		class Item119
 		{
 			dataType="Group";
 			side="East";
@@ -22342,7 +22138,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_MAT1_FTL";
-						description="OpFor Medium AT Team 1 Leader@Medium AT Team 1";
+						description="OpFor Medium AT Team 1 Leader@OpFor Medium AT Team 1";
 						isPlayable=1;
 					};
 					id=1169;
@@ -22452,7 +22248,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item125
+		class Item120
 		{
 			dataType="Group";
 			side="East";
@@ -22472,7 +22268,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_MAT2_FTL";
-						description="OpFor Medium AT Team 2 Leader@Medium AT Team 2";
+						description="OpFor Medium AT Team 2 Leader@OpFor Medium AT Team 2";
 						isPlayable=1;
 					};
 					id=1173;
@@ -22582,7 +22378,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item126
+		class Item121
 		{
 			dataType="Group";
 			side="East";
@@ -22602,7 +22398,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_MTR1_FTL";
-						description="OpFor Mortar Team 1 Leader@Mortar Team 1";
+						description="OpFor Mortar Team 1 Leader@OpFor Mortar Team 1";
 						isPlayable=1;
 					};
 					id=1177;
@@ -22712,7 +22508,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item127
+		class Item122
 		{
 			dataType="Group";
 			side="East";
@@ -22732,7 +22528,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_MSAM1_FTL";
-						description="OpFor Medium SAM Team 1 Leader@Medium SAM Team 1";
+						description="OpFor Medium SAM Team 1 Leader@OpFor Medium SAM Team 1";
 						isPlayable=1;
 					};
 					id=1181;
@@ -22842,7 +22638,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item128
+		class Item123
 		{
 			dataType="Group";
 			side="East";
@@ -22862,7 +22658,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_WSL_SL";
-						description="OpFor Weapon Squad Leader@Weapon Squad";
+						description="OpFor Weapon Squad Leader@OpFor Weapon Squad";
 						isPlayable=1;
 					};
 					id=1185;
@@ -22981,7 +22777,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item129
+		class Item124
 		{
 			dataType="Group";
 			side="East";
@@ -23001,7 +22797,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_ST1_SP";
-						description="OpFor Sniper Team 1 Spotter@Sniper Team 1";
+						description="OpFor Sniper Team 1 Spotter@OpFor Sniper Team 1";
 						isPlayable=1;
 					};
 					id=1188;
@@ -23093,7 +22889,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item130
+		class Item125
 		{
 			dataType="Group";
 			side="East";
@@ -23113,7 +22909,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_ENG1_FTL";
-						description="OpFor Leader Explosive Specialist@Demolitions Team";
+						description="OpFor Leader Explosive Specialist@OpFor Demolitions Team";
 						isPlayable=1;
 					};
 					id=1191;
@@ -23241,7 +23037,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item131
+		class Item126
 		{
 			dataType="Group";
 			side="East";
@@ -23261,7 +23057,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_OPF_DSL_SL";
-						description="OpFor Delta Squad Leader@Delta Squad";
+						description="OpFor Delta Squad Leader@OpFor Delta Squad";
 						isPlayable=1;
 					};
 					id=1196;
@@ -23381,7 +23177,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item132
+		class Item127
 		{
 			dataType="Group";
 			side="East";
@@ -23401,7 +23197,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_D1_FTL";
-						description="OpFor Delta 1 Fireteam Leader@Delta Fireteam 1";
+						description="OpFor Delta 1 Fireteam Leader@OpFor Delta Fireteam 1";
 						isPlayable=1;
 					};
 					id=1199;
@@ -23657,7 +23453,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item133
+		class Item128
 		{
 			dataType="Group";
 			side="East";
@@ -23677,7 +23473,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_D2_FTL";
-						description="OpFor Delta 2 Fireteam Leader@Delta Fireteam 2";
+						description="OpFor Delta 2 Fireteam Leader@OpFor Delta Fireteam 2";
 						isPlayable=1;
 					};
 					id=1206;
@@ -23933,7 +23729,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item134
+		class Item129
 		{
 			dataType="Group";
 			side="East";
@@ -23953,7 +23749,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_OPF_ESL_SL";
-						description="OpFor Echo Squad Leader@Echo Squad";
+						description="OpFor Echo Squad Leader@OpFor Echo Squad";
 						isPlayable=1;
 					};
 					id=1213;
@@ -24073,7 +23869,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item135
+		class Item130
 		{
 			dataType="Group";
 			side="East";
@@ -24093,7 +23889,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_E1_FTL";
-						description="OpFor Echo 1 Fireteam Leader@Echo Fireteam 1";
+						description="OpFor Echo 1 Fireteam Leader@OpFor Echo Fireteam 1";
 						isPlayable=1;
 					};
 					id=1216;
@@ -24349,7 +24145,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item136
+		class Item131
 		{
 			dataType="Group";
 			side="East";
@@ -24369,7 +24165,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_E2_FTL";
-						description="OpFor Echo 2 Fireteam Leader@Echo Fireteam 2";
+						description="OpFor Echo 2 Fireteam Leader@OpFor Echo Fireteam 2";
 						isPlayable=1;
 					};
 					id=1223;
@@ -24625,7 +24421,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item137
+		class Item132
 		{
 			dataType="Group";
 			side="East";
@@ -24645,7 +24441,7 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_OPF_FSL_SL";
-						description="OpFor Foxtrot Squad Leader@Foxtrot Squad";
+						description="OpFor Foxtrot Squad Leader@OpFor Foxtrot Squad";
 						isPlayable=1;
 					};
 					id=1230;
@@ -24765,7 +24561,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item138
+		class Item133
 		{
 			dataType="Group";
 			side="East";
@@ -24785,7 +24581,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_F1_FTL";
-						description="OpFor Foxtrot 1 Fireteam Leader@Foxtrot Fireteam 1";
+						description="OpFor Foxtrot 1 Fireteam Leader@OpFor Foxtrot Fireteam 1";
 						isPlayable=1;
 					};
 					id=1233;
@@ -25041,7 +24837,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item139
+		class Item134
 		{
 			dataType="Group";
 			side="East";
@@ -25061,7 +24857,7 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_OPF_F2_FTL";
-						description="OpFor Foxtrot 2 Fireteam Leader@Foxtrot Fireteam 2";
+						description="OpFor Foxtrot 2 Fireteam Leader@OpFor Foxtrot Fireteam 2";
 						isPlayable=1;
 					};
 					id=1240;
@@ -25317,7 +25113,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item140
+		class Item135
 		{
 			dataType="Group";
 			side="East";
@@ -25329,14 +25125,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={736.13287,5.0014391,760.39221};
+						position[]={736.133,5.0014391,760.39197};
 					};
 					side="East";
 					flags=6;
 					class Attributes
 					{
 						rank="LIEUTENANT";
-						description="JIP Offcer (CO/XO/Plt/Sgt)";
+						description="JIP Offcer (CO/XO/Plt/Sgt)@OpFor JIP Squad";
 						isPlayable=1;
 					};
 					id=1252;
@@ -26069,7 +25865,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item141
+		class Item136
 		{
 			dataType="Group";
 			side="East";
@@ -26081,7 +25877,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={751.46179,5.0014391,636.12012};
+						position[]={751.71149,5.0014391,648.29382};
 					};
 					side="East";
 					flags=6;
@@ -26089,7 +25885,7 @@ class Mission
 					{
 						rank="LIEUTENANT";
 						name="UNIT_MSV_COY_CO";
-						description="Russian Company Commander@Company";
+						description="Russian Company Commander@Russian Company";
 						isPlayable=1;
 					};
 					id=1492;
@@ -26100,7 +25896,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={746.76935,5.0014391,630.87982};
+						position[]={747.01904,5.0014391,643.05353};
 					};
 					side="East";
 					flags=4;
@@ -26119,7 +25915,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={742.07751,5.0014391,625.59064};
+						position[]={742.32721,5.0014391,637.76434};
 					};
 					side="East";
 					flags=4;
@@ -26160,7 +25956,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={762.0415,5.0014391,626.78503};
+						position[]={762.2912,5.0014391,638.95874};
 					};
 					side="East";
 					flags=4;
@@ -26178,7 +25974,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={756.75134,5.0014391,631.47687};
+						position[]={757.00104,5.0014391,643.65057};
 					};
 					side="East";
 					flags=4;
@@ -26260,7 +26056,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item142
+		class Item137
 		{
 			dataType="Group";
 			side="East";
@@ -26272,7 +26068,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={764.5871,5.0014391,623.58368};
+						position[]={720.23071,5.0014391,637.9519};
 					};
 					side="East";
 					flags=6;
@@ -26280,7 +26076,7 @@ class Mission
 					{
 						rank="LIEUTENANT";
 						name="UNIT_MSV_1PLT_CO";
-						description="Russian First Platoon Commander@1st Platoon (Alpha, Bravo, Charlie)";
+						description="Russian First Platoon Commander@Russian 1st Platoon (Alpha, Bravo, Charlie)";
 						isPlayable=1;
 					};
 					id=1498;
@@ -26291,7 +26087,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={770.10828,5.0014391,619.21686};
+						position[]={722.27539,5.0014391,635.71356};
 					};
 					side="East";
 					flags=4;
@@ -26373,7 +26169,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item143
+		class Item138
 		{
 			dataType="Group";
 			side="East";
@@ -26385,7 +26181,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={740.34808,5.0014391,624.51428};
+						position[]={751.99603,5.0014391,638.07867};
 					};
 					side="East";
 					flags=6;
@@ -26393,7 +26189,7 @@ class Mission
 					{
 						rank="LIEUTENANT";
 						name="UNIT_MSV_2PLT_CO";
-						description="Russian Second Platoon Commander@2nd Platoon (Delta, Echo, Foxtrot)";
+						description="Russian Second Platoon Commander@Russian 2nd Platoon (Delta, Echo, Foxtrot)";
 						isPlayable=1;
 					};
 					id=1501;
@@ -26404,7 +26200,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={736.75531,5.0014391,621.66321};
+						position[]={754.15234,5.0014391,635.89471};
 					};
 					side="East";
 					flags=4;
@@ -26486,6 +26282,159 @@ class Mission
 				nAttributes=3;
 			};
 		};
+		class Item139
+		{
+			dataType="Comment";
+			class PositionInfo
+			{
+				position[]={751.87299,5,836.71899};
+			};
+			title="Opfor Units";
+			id=1544;
+		};
+		class Item140
+		{
+			dataType="Comment";
+			class PositionInfo
+			{
+				position[]={652.80688,5,874.81964};
+			};
+			title="Civilian Units";
+			id=1545;
+		};
+		class Item141
+		{
+			dataType="Comment";
+			class PositionInfo
+			{
+				position[]={751.38702,5,962.84302};
+			};
+			title="Bluefor Units";
+			id=1546;
+		};
+		class Item142
+		{
+			dataType="Comment";
+			class PositionInfo
+			{
+				position[]={559.45099,5,963.74902};
+			};
+			title="Independent Units";
+			id=1547;
+		};
+		class Item143
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={784.341,5.0014391,638.25098};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						rank="LIEUTENANT";
+						name="UNIT_MSV_3PLT_CO";
+						description="Russian Third Platoon Commander@Russian 3rd Platoon (Golf, Hotel, India)";
+						isPlayable=1;
+					};
+					id=1949;
+					type="potato_msv_plt";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={786.49799,5.0014391,636.06702};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_3PLT_XO";
+						description="Russian Third Platoon Assistant Leader";
+						isPlayable=1;
+					};
+					id=1950;
+					type="potato_msv_aplt";
+				};
+			};
+			class Attributes
+			{
+				name="GROUP_MSV_3PLT";
+			};
+			id=1948;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="potato_markers_addMarker";
+					expression="[_this,_value] call potato_markers_fnc_setMarker;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="3PLT,24,orange,\z\potato\addons\markers\data\hq.paa";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="groupID";
+					expression="[_this, _value] call CBA_fnc_setCallsign";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="MSV 3PLT";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="potato_radios_radio";
+					expression="[_this,_value] call potato_radios_fnc_setChannels";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="11,2,3";
+						};
+					};
+				};
+				nAttributes=3;
+			};
+		};
 		class Item144
 		{
 			dataType="Group";
@@ -26498,7 +26447,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={777.09125,5.0014391,614.76227};
+						position[]={708.79803,5.0014391,626.53302};
 					};
 					side="East";
 					flags=6;
@@ -26506,10 +26455,10 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_MSV_A_SL";
-						description="Russian Alpha Squad Leader@Alpha Squad";
+						description="Russian Alpha Squad Leader@Russian Alpha Squad";
 						isPlayable=1;
 					};
-					id=1504;
+					id=1952;
 					type="potato_msv_sl";
 				};
 				class Item1
@@ -26517,7 +26466,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={778.54327,5.0014391,614.64929};
+						position[]={710.25006,5.0014391,626.42004};
 					};
 					side="East";
 					flags=4;
@@ -26528,7 +26477,7 @@ class Mission
 						description="Russian Alpha Squad Vehicle Gunner";
 						isPlayable=1;
 					};
-					id=1505;
+					id=1953;
 					type="potato_msv_vicc";
 					class CustomAttributes
 					{
@@ -26578,7 +26527,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={780.07379,5.0014391,614.72943};
+						position[]={711.78058,5.0014391,626.50018};
 					};
 					side="East";
 					flags=4;
@@ -26589,7 +26538,7 @@ class Mission
 						description="Russian Alpha Squad Vehicle Driver";
 						isPlayable=1;
 					};
-					id=1506;
+					id=1954;
 					type="potato_msv_vicd";
 					class CustomAttributes
 					{
@@ -26620,7 +26569,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={777.22058,5.0014391,612.82239};
+						position[]={708.92737,5.0014391,624.59314};
 					};
 					side="East";
 					flags=4;
@@ -26631,7 +26580,7 @@ class Mission
 						description="Russian Alpha Squad Senior Rifleman";
 						isPlayable=1;
 					};
-					id=1507;
+					id=1955;
 					type="potato_msv_sr";
 					class CustomAttributes
 					{
@@ -26654,7 +26603,26 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						class Attribute1
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=2;
 					};
 				};
 				class Item4
@@ -26662,7 +26630,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={778.69836,5.0014391,612.80933};
+						position[]={710.40515,5.0014391,624.58008};
 					};
 					side="East";
 					flags=4;
@@ -26673,15 +26641,38 @@ class Mission
 						description="Russian Alpha Squad Rifleman";
 						isPlayable=1;
 					};
-					id=1508;
+					id=1956;
 					type="potato_msv_rifleman";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 				class Item5
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={780.13953,5.0014391,612.82849};
+						position[]={711.84631,5.0014391,624.59924};
 					};
 					side="East";
 					flags=4;
@@ -26691,7 +26682,7 @@ class Mission
 						description="Russian Alpha Squad Medic";
 						isPlayable=1;
 					};
-					id=1509;
+					id=1957;
 					type="potato_msv_sm";
 					class CustomAttributes
 					{
@@ -26741,7 +26732,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={777.09259,5.0014391,611.18341};
+						position[]={708.79938,5.0014391,622.95416};
 					};
 					side="East";
 					flags=4;
@@ -26751,7 +26742,7 @@ class Mission
 						description="Russian Alpha Squad Automatic Rifleman";
 						isPlayable=1;
 					};
-					id=1510;
+					id=1958;
 					type="potato_msv_ar";
 					class CustomAttributes
 					{
@@ -26782,7 +26773,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={778.61359,5.0014391,611.05847};
+						position[]={710.32037,5.0014391,622.82922};
 					};
 					side="East";
 					flags=4;
@@ -26792,7 +26783,7 @@ class Mission
 						description="Russian Alpha Squad Grenadier";
 						isPlayable=1;
 					};
-					id=1511;
+					id=1959;
 					type="potato_msv_g";
 					class CustomAttributes
 					{
@@ -26823,7 +26814,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={780.04755,5.0014391,611.13647};
+						position[]={711.75433,5.0014391,622.90723};
 					};
 					side="East";
 					flags=4;
@@ -26833,7 +26824,7 @@ class Mission
 						description="Russian Alpha Squad Assistant Grenadier";
 						isPlayable=1;
 					};
-					id=1512;
+					id=1960;
 					type="potato_msv_ag";
 					class CustomAttributes
 					{
@@ -26864,7 +26855,7 @@ class Mission
 			{
 				name="GROUP_MSV_A";
 			};
-			id=1503;
+			id=1951;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -26920,7 +26911,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={788.4295,5.0014391,614.68103};
+						position[]={717.83813,5.0014391,626.35248};
 					};
 					side="East";
 					flags=6;
@@ -26928,10 +26919,10 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_MSV_B_SL";
-						description="Russian Bravo Squad Leader@Bravo Squad";
+						description="Russian Bravo Squad Leader@Russian Bravo Squad";
 						isPlayable=1;
 					};
-					id=1513;
+					id=1962;
 					type="potato_msv_sl";
 				};
 				class Item1
@@ -26939,7 +26930,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={790.02216,5.0014391,614.69116};
+						position[]={719.43079,5.0014391,626.36261};
 					};
 					side="East";
 					flags=4;
@@ -26950,7 +26941,7 @@ class Mission
 						description="Russian Bravo Squad Vehicle Gunner";
 						isPlayable=1;
 					};
-					id=1514;
+					id=1963;
 					type="potato_msv_vicc";
 					class CustomAttributes
 					{
@@ -27000,7 +26991,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={791.9162,5.0014391,614.43829};
+						position[]={721.32483,5.0014391,626.10974};
 					};
 					side="East";
 					flags=4;
@@ -27011,7 +27002,7 @@ class Mission
 						description="Russian Bravo Squad Vehicle Driver";
 						isPlayable=1;
 					};
-					id=1515;
+					id=1964;
 					type="potato_msv_vicd";
 					class CustomAttributes
 					{
@@ -27042,7 +27033,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={788.44165,5.0014391,612.98206};
+						position[]={717.85028,5.0014391,624.6535};
 					};
 					side="East";
 					flags=4;
@@ -27053,7 +27044,7 @@ class Mission
 						description="Russian Bravo Squad Senior Rifleman";
 						isPlayable=1;
 					};
-					id=1516;
+					id=1965;
 					type="potato_msv_sr";
 					class CustomAttributes
 					{
@@ -27091,7 +27082,7 @@ class Mission
 											"STRING"
 										};
 									};
-									value="YELLOW";
+									value="GREEN";
 								};
 							};
 						};
@@ -27103,7 +27094,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={789.97864,5.0014391,613.01007};
+						position[]={719.38727,5.0014391,624.68152};
 					};
 					side="East";
 					flags=4;
@@ -27114,44 +27105,8 @@ class Mission
 						description="Russian Bravo Squad Marksman";
 						isPlayable=1;
 					};
-					id=1517;
+					id=1966;
 					type="potato_msv_marksman";
-				};
-				class Item5
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={788.5047,5.0014391,611.29205};
-					};
-					side="East";
-					flags=4;
-					class Attributes
-					{
-						name="UNIT_MSV_B_AR";
-						description="Russian Bravo Squad Automatic Rifleman";
-						isPlayable=1;
-					};
-					id=1519;
-					type="potato_msv_ar";
-				};
-				class Item6
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={791.71661,5.0014391,611.29211};
-					};
-					side="East";
-					flags=4;
-					class Attributes
-					{
-						name="UNIT_MSV_B_AGR";
-						description="Russian Bravo Squad Assistant Grenadier";
-						isPlayable=1;
-					};
-					id=1521;
-					type="potato_msv_ag";
 					class CustomAttributes
 					{
 						class Attribute0
@@ -27169,19 +27124,19 @@ class Mission
 											"STRING"
 										};
 									};
-									value="RED";
+									value="GREEN";
 								};
 							};
 						};
 						nAttributes=1;
 					};
 				};
-				class Item7
+				class Item5
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={791.84698,5.0014391,612.86798};
+						position[]={721.25562,5.0014391,624.53943};
 					};
 					side="East";
 					flags=4;
@@ -27191,30 +27146,11 @@ class Mission
 						description="Russian Bravo Squad Medic";
 						isPlayable=1;
 					};
-					id=1907;
+					id=1967;
 					type="potato_msv_sm";
 					class CustomAttributes
 					{
 						class Attribute0
-						{
-							property="potato_teamColors_teamColor";
-							expression="[_this,_value] call potato_teamColors_fnc_setColor";
-							class Value
-							{
-								class data
-								{
-									class type
-									{
-										type[]=
-										{
-											"STRING"
-										};
-									};
-									value="MAIN";
-								};
-							};
-						};
-						class Attribute1
 						{
 							property="potato_markers_addMarker";
 							expression="[_this,_value] call potato_markers_fnc_setMarker;";
@@ -27233,15 +27169,52 @@ class Mission
 								};
 							};
 						};
+						class Attribute1
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="MAIN";
+								};
+							};
+						};
 						nAttributes=2;
 					};
 				};
-				class Item8
+				class Item6
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={789.89697,5.0014391,611.14899};
+						position[]={717.91333,5.0014391,622.9635};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_B_AR";
+						description="Russian Bravo Squad Automatic Rifleman";
+						isPlayable=1;
+					};
+					id=1968;
+					type="potato_msv_ar";
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={719.3056,5.0014391,622.82043};
 					};
 					side="East";
 					flags=4;
@@ -27251,7 +27224,7 @@ class Mission
 						description="Russian Bravo Squad Grenadier";
 						isPlayable=1;
 					};
-					id=1908;
+					id=1969;
 					type="potato_msv_g";
 					class CustomAttributes
 					{
@@ -27277,12 +27250,53 @@ class Mission
 						nAttributes=1;
 					};
 				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={721.12524,5.0014391,622.96356};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_B_AGR";
+						description="Russian Bravo Squad Assistant Grenadier";
+						isPlayable=1;
+					};
+					id=1970;
+					type="potato_msv_ag";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="RED";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
 			};
 			class Attributes
 			{
 				name="GROUP_MSV_B";
 			};
-			id=1330;
+			id=1961;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -27357,7 +27371,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={798.93726,5.0014391,614.1181};
+						position[]={726.5661,5.0014391,626.28577};
 					};
 					side="East";
 					flags=6;
@@ -27365,10 +27379,10 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_MSV_C_SL";
-						description="Russian Charlie Squad Leader@Charlie Squad";
+						description="Russian Charlie Squad Leader@Russian Charlie Squad";
 						isPlayable=1;
 					};
-					id=1534;
+					id=1972;
 					type="potato_msv_sl";
 				};
 				class Item1
@@ -27376,7 +27390,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={801.60431,5.0014391,613.8642};
+						position[]={729.23315,5.0014391,626.03186};
 					};
 					side="East";
 					flags=4;
@@ -27387,7 +27401,7 @@ class Mission
 						description="Russian Charlie Squad Vehicle Driver";
 						isPlayable=1;
 					};
-					id=1535;
+					id=1973;
 					type="potato_msv_vicd";
 					class CustomAttributes
 					{
@@ -27418,7 +27432,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={800.38397,5.0014391,613.9165};
+						position[]={728.01282,5.0014391,626.08417};
 					};
 					side="East";
 					flags=4;
@@ -27429,7 +27443,7 @@ class Mission
 						description="Russian Charlie Squad Vehicle Gunner";
 						isPlayable=1;
 					};
-					id=1536;
+					id=1974;
 					type="potato_msv_vicc";
 					class CustomAttributes
 					{
@@ -27479,7 +27493,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={798.95587,5.0014391,612.71851};
+						position[]={726.58472,5.0014391,624.88617};
 					};
 					side="East";
 					flags=4;
@@ -27490,7 +27504,7 @@ class Mission
 						description="Russian Charlie Squad Senior Rifleman";
 						isPlayable=1;
 					};
-					id=1537;
+					id=1975;
 					type="potato_msv_sr";
 					class CustomAttributes
 					{
@@ -27513,7 +27527,26 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						class Attribute1
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=2;
 					};
 				};
 				class Item4
@@ -27521,7 +27554,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={800.29449,5.0014391,612.65106};
+						position[]={727.92334,5.0014391,624.81873};
 					};
 					side="East";
 					flags=4;
@@ -27532,15 +27565,38 @@ class Mission
 						description="Russian Charlie Squad Rifleman";
 						isPlayable=1;
 					};
-					id=1538;
+					id=1976;
 					type="potato_msv_rifleman";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 				class Item5
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={801.56525,5.0014391,612.39221};
+						position[]={729.19409,5.0014391,624.55988};
 					};
 					side="East";
 					flags=4;
@@ -27550,7 +27606,7 @@ class Mission
 						description="Russian Charlie Squad Medic";
 						isPlayable=1;
 					};
-					id=1539;
+					id=1977;
 					type="potato_msv_sm";
 					class CustomAttributes
 					{
@@ -27600,7 +27656,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={798.88232,5.0014391,611.14508};
+						position[]={726.51117,5.0014391,623.31274};
 					};
 					side="East";
 					flags=4;
@@ -27610,7 +27666,7 @@ class Mission
 						description="Russian Charlie Squad Automatic Rifleman";
 						isPlayable=1;
 					};
-					id=1540;
+					id=1978;
 					type="potato_msv_ar";
 					class CustomAttributes
 					{
@@ -27641,7 +27697,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={800.29138,5.0014391,611.14716};
+						position[]={727.92023,5.0014391,623.31482};
 					};
 					side="East";
 					flags=4;
@@ -27651,7 +27707,7 @@ class Mission
 						description="Russian Charlie Squad Grenadier";
 						isPlayable=1;
 					};
-					id=1541;
+					id=1979;
 					type="potato_msv_g";
 					class CustomAttributes
 					{
@@ -27682,7 +27738,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={801.6123,5.0014391,610.91724};
+						position[]={729.24115,5.0014391,623.0849};
 					};
 					side="East";
 					flags=4;
@@ -27692,7 +27748,7 @@ class Mission
 						description="Russian Charlie Squad Assistant Grenadier";
 						isPlayable=1;
 					};
-					id=1542;
+					id=1980;
 					type="potato_msv_ag";
 					class CustomAttributes
 					{
@@ -27723,7 +27779,7 @@ class Mission
 			{
 				name="GROUP_MSV_C";
 			};
-			id=1533;
+			id=1971;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -27788,56 +27844,6 @@ class Mission
 		};
 		class Item147
 		{
-			dataType="Comment";
-			class PositionInfo
-			{
-				position[]={751.8075,5,627.98602};
-			};
-			title="MSV Units";
-			id=1543;
-		};
-		class Item148
-		{
-			dataType="Comment";
-			class PositionInfo
-			{
-				position[]={751.87299,5,836.71899};
-			};
-			title="Opfor Units";
-			id=1544;
-		};
-		class Item149
-		{
-			dataType="Comment";
-			class PositionInfo
-			{
-				position[]={652.80688,5,874.81964};
-			};
-			title="Civilian Units";
-			id=1545;
-		};
-		class Item150
-		{
-			dataType="Comment";
-			class PositionInfo
-			{
-				position[]={751.38702,5,962.84302};
-			};
-			title="Bluefor Units";
-			id=1546;
-		};
-		class Item151
-		{
-			dataType="Comment";
-			class PositionInfo
-			{
-				position[]={559.45099,5,963.74902};
-			};
-			title="Independent Units";
-			id=1547;
-		};
-		class Item152
-		{
 			dataType="Group";
 			side="East";
 			class Entities
@@ -27848,7 +27854,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={724.67908,5.0014391,618.85693};
+						position[]={741.099,5.0014391,626.38293};
 					};
 					side="East";
 					flags=6;
@@ -27856,10 +27862,10 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_MSV_D_SL";
-						description="Russian Delta Squad Leader@Delta Squad";
+						description="Russian Delta Squad Leader@Russian Delta Squad";
 						isPlayable=1;
 					};
-					id=1578;
+					id=1983;
 					type="potato_msv_sl";
 				};
 				class Item1
@@ -27867,7 +27873,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={726.69415,5.0014391,618.7901};
+						position[]={743.11407,5.0014391,626.3161};
 					};
 					side="East";
 					flags=4;
@@ -27878,7 +27884,7 @@ class Mission
 						description="Russian Delta Squad Vehicle Gunner";
 						isPlayable=1;
 					};
-					id=1579;
+					id=1984;
 					type="potato_msv_vicc";
 					class CustomAttributes
 					{
@@ -27928,7 +27934,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={728.70667,5.0014391,618.81708};
+						position[]={745.12659,5.0014391,626.34308};
 					};
 					side="East";
 					flags=4;
@@ -27939,7 +27945,7 @@ class Mission
 						description="Russian Delta Squad Vehicle Driver";
 						isPlayable=1;
 					};
-					id=1580;
+					id=1985;
 					type="potato_msv_vicd";
 					class CustomAttributes
 					{
@@ -27970,7 +27976,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={724.62762,5.0014391,616.84003};
+						position[]={741.04755,5.0014391,624.36603};
 					};
 					side="East";
 					flags=4;
@@ -27981,7 +27987,7 @@ class Mission
 						description="Russian Delta Squad Senior Rifleman";
 						isPlayable=1;
 					};
-					id=1581;
+					id=1986;
 					type="potato_msv_sr";
 					class CustomAttributes
 					{
@@ -28004,7 +28010,26 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						class Attribute1
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=2;
 					};
 				};
 				class Item4
@@ -28012,7 +28037,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={726.72858,5.0014391,616.8421};
+						position[]={743.1485,5.0014391,624.3681};
 					};
 					side="East";
 					flags=4;
@@ -28023,15 +28048,38 @@ class Mission
 						description="Russian Delta Squad Rifleman";
 						isPlayable=1;
 					};
-					id=1582;
+					id=1987;
 					type="potato_msv_rifleman";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 				class Item5
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={728.66461,5.0014391,616.75818};
+						position[]={745.08453,5.0014391,624.28418};
 					};
 					side="East";
 					flags=4;
@@ -28041,7 +28089,7 @@ class Mission
 						description="Russian Delta Squad Medic";
 						isPlayable=1;
 					};
-					id=1583;
+					id=1988;
 					type="potato_msv_sm";
 					class CustomAttributes
 					{
@@ -28091,7 +28139,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={724.65369,5.0014391,614.76404};
+						position[]={741.07361,5.0014391,622.29004};
 					};
 					side="East";
 					flags=4;
@@ -28101,7 +28149,7 @@ class Mission
 						description="Russian Delta Squad Automatic Rifleman";
 						isPlayable=1;
 					};
-					id=1584;
+					id=1989;
 					type="potato_msv_ar";
 					class CustomAttributes
 					{
@@ -28132,7 +28180,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={726.71265,5.0014391,614.83209};
+						position[]={743.13257,5.0014391,622.35809};
 					};
 					side="East";
 					flags=4;
@@ -28142,7 +28190,7 @@ class Mission
 						description="Russian Delta Squad Grenadier";
 						isPlayable=1;
 					};
-					id=1585;
+					id=1990;
 					type="potato_msv_g";
 					class CustomAttributes
 					{
@@ -28173,7 +28221,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={728.71967,5.0014391,614.77325};
+						position[]={745.13959,5.0014391,622.29926};
 					};
 					side="East";
 					flags=4;
@@ -28183,7 +28231,7 @@ class Mission
 						description="Russian Delta Squad Assistant Grenadier";
 						isPlayable=1;
 					};
-					id=1586;
+					id=1991;
 					type="potato_msv_ag";
 					class CustomAttributes
 					{
@@ -28214,7 +28262,7 @@ class Mission
 			{
 				name="GROUP_MSV_D";
 			};
-			id=1577;
+			id=1982;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -28277,7 +28325,17 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item153
+		class Item148
+		{
+			dataType="Comment";
+			class PositionInfo
+			{
+				position[]={751.44257,5,623.07404};
+			};
+			title="MSV Units";
+			id=2278;
+		};
+		class Item149
 		{
 			dataType="Group";
 			side="East";
@@ -28289,7 +28347,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={711.23743,5.0014391,619.07269};
+						position[]={749.9325,5.0014391,625.9068};
 					};
 					side="East";
 					flags=6;
@@ -28297,10 +28355,10 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_MSV_E_SL";
-						description="Russian Echo Squad Leader@Echo Squad";
+						description="Russian Echo Squad Leader@Russian Echo Squad";
 						isPlayable=1;
 					};
-					id=1597;
+					id=2280;
 					type="potato_msv_sl";
 				};
 				class Item1
@@ -28308,7 +28366,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={713.21588,5.0014391,619.03149};
+						position[]={751.91095,5.0014391,625.8656};
 					};
 					side="East";
 					flags=4;
@@ -28319,7 +28377,7 @@ class Mission
 						description="Russian Echo Squad Vehicle Gunner";
 						isPlayable=1;
 					};
-					id=1598;
+					id=2281;
 					type="potato_msv_vicc";
 					class CustomAttributes
 					{
@@ -28369,7 +28427,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={715.2464,5.0014391,619.00287};
+						position[]={753.94147,5.0014391,625.83698};
 					};
 					side="East";
 					flags=4;
@@ -28380,7 +28438,7 @@ class Mission
 						description="Russian Echo Squad Vehicle Driver";
 						isPlayable=1;
 					};
-					id=1599;
+					id=2282;
 					type="potato_msv_vicd";
 					class CustomAttributes
 					{
@@ -28411,7 +28469,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={711.17053,5.0014391,616.95868};
+						position[]={749.8656,5.0014391,623.79279};
 					};
 					side="East";
 					flags=4;
@@ -28422,7 +28480,7 @@ class Mission
 						description="Russian Echo Squad Senior Rifleman";
 						isPlayable=1;
 					};
-					id=1600;
+					id=2283;
 					type="potato_msv_sr";
 					class CustomAttributes
 					{
@@ -28445,7 +28503,26 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						class Attribute1
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=2;
 					};
 				};
 				class Item4
@@ -28453,7 +28530,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={713.29053,5.0014391,617.05383};
+						position[]={751.9856,5.0014391,623.88794};
 					};
 					side="East";
 					flags=4;
@@ -28464,15 +28541,38 @@ class Mission
 						description="Russian Echo Squad Marksman";
 						isPlayable=1;
 					};
-					id=1601;
+					id=2284;
 					type="potato_msv_marksman";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 				class Item5
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={715.15649,5.0014391,617.02991};
+						position[]={753.85156,5.0014391,623.86401};
 					};
 					side="East";
 					flags=4;
@@ -28482,7 +28582,7 @@ class Mission
 						description="Russian Echo Squad Medic";
 						isPlayable=1;
 					};
-					id=1602;
+					id=2285;
 					type="potato_msv_sm";
 					class CustomAttributes
 					{
@@ -28532,7 +28632,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={711.17352,5.0014391,615.04468};
+						position[]={749.86859,5.0014391,621.87878};
 					};
 					side="East";
 					flags=4;
@@ -28542,7 +28642,7 @@ class Mission
 						description="Russian Echo Squad Automatic Rifleman";
 						isPlayable=1;
 					};
-					id=1603;
+					id=2286;
 					type="potato_msv_ar";
 					class CustomAttributes
 					{
@@ -28573,7 +28673,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={713.19452,5.0014391,614.96985};
+						position[]={751.88959,5.0014391,621.80396};
 					};
 					side="East";
 					flags=4;
@@ -28583,7 +28683,7 @@ class Mission
 						description="Russian Echo Squad Grenadier";
 						isPlayable=1;
 					};
-					id=1604;
+					id=2287;
 					type="potato_msv_g";
 					class CustomAttributes
 					{
@@ -28614,7 +28714,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={715.31451,5.0014391,615.04187};
+						position[]={754.00958,5.0014391,621.87598};
 					};
 					side="East";
 					flags=4;
@@ -28624,7 +28724,7 @@ class Mission
 						description="Russian Echo Squad Assistant Grenadier";
 						isPlayable=1;
 					};
-					id=1605;
+					id=2288;
 					type="potato_msv_ag";
 					class CustomAttributes
 					{
@@ -28655,7 +28755,7 @@ class Mission
 			{
 				name="GROUP_MSV_E";
 			};
-			id=1596;
+			id=2279;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -28718,7 +28818,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item154
+		class Item150
 		{
 			dataType="Group";
 			side="East";
@@ -28730,7 +28830,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={696.66412,5.0014391,619.74707};
+						position[]={758.3222,5.0014391,625.77911};
 					};
 					side="East";
 					flags=6;
@@ -28738,10 +28838,10 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_MSV_F_SL";
-						description="Russian Foxtrot Squad Leader@Foxtrot Squad";
+						description="Russian Foxtrot Squad Leader@Russian Foxtrot Squad";
 						isPlayable=1;
 					};
-					id=1636;
+					id=2433;
 					type="potato_msv_sl";
 				};
 				class Item1
@@ -28749,7 +28849,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={698.53986,5.0014391,619.5752};
+						position[]={760.19794,5.0014391,625.60724};
 					};
 					side="East";
 					flags=4;
@@ -28760,7 +28860,7 @@ class Mission
 						description="Russian Foxtrot Squad Vehicle Gunner";
 						isPlayable=1;
 					};
-					id=1637;
+					id=2434;
 					type="potato_msv_vicc";
 					class CustomAttributes
 					{
@@ -28810,7 +28910,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={700.75214,5.0014391,619.64221};
+						position[]={762.41022,5.0014391,625.67426};
 					};
 					side="East";
 					flags=4;
@@ -28821,7 +28921,7 @@ class Mission
 						description="Russian Foxtrot Squad Vehicle Driver";
 						isPlayable=1;
 					};
-					id=1638;
+					id=2435;
 					type="potato_msv_vicd";
 					class CustomAttributes
 					{
@@ -28852,7 +28952,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={696.63623,5.0014391,617.51611};
+						position[]={758.29431,5.0014391,623.54816};
 					};
 					side="East";
 					flags=4;
@@ -28862,7 +28962,7 @@ class Mission
 						description="Russian Foxtrot Squad Senior Rifleman";
 						isPlayable=1;
 					};
-					id=1639;
+					id=2436;
 					type="potato_msv_sr";
 					class CustomAttributes
 					{
@@ -28885,7 +28985,26 @@ class Mission
 								};
 							};
 						};
-						nAttributes=1;
+						class Attribute1
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=2;
 					};
 				};
 				class Item4
@@ -28893,7 +29012,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={698.70819,5.0014391,617.65717};
+						position[]={760.36627,5.0014391,623.68921};
 					};
 					side="East";
 					flags=4;
@@ -28904,15 +29023,38 @@ class Mission
 						description="Russian Foxtrot Squad Rifleman";
 						isPlayable=1;
 					};
-					id=1640;
+					id=2437;
 					type="potato_msv_rifleman";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=1;
+					};
 				};
 				class Item5
 				{
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={700.59619,5.0014391,617.61719};
+						position[]={762.25427,5.0014391,623.64923};
 					};
 					side="East";
 					flags=4;
@@ -28922,7 +29064,7 @@ class Mission
 						description="Russian Foxtrot Squad Medic";
 						isPlayable=1;
 					};
-					id=1641;
+					id=2438;
 					type="potato_msv_sm";
 					class CustomAttributes
 					{
@@ -28972,7 +29114,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={696.58527,5.0014391,615.65308};
+						position[]={758.24335,5.0014391,621.68512};
 					};
 					side="East";
 					flags=4;
@@ -28982,7 +29124,7 @@ class Mission
 						description="Russian Foxtrot Squad Automatic Rifleman";
 						isPlayable=1;
 					};
-					id=1642;
+					id=2439;
 					type="potato_msv_ar";
 					class CustomAttributes
 					{
@@ -29013,7 +29155,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={698.54425,5.0014391,615.60217};
+						position[]={760.20233,5.0014391,621.63422};
 					};
 					side="East";
 					flags=4;
@@ -29023,7 +29165,7 @@ class Mission
 						description="Russian Foxtrot Squad Grenadier";
 						isPlayable=1;
 					};
-					id=1643;
+					id=2440;
 					type="potato_msv_g";
 					class CustomAttributes
 					{
@@ -29054,7 +29196,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={700.65729,5.0014391,615.60419};
+						position[]={762.31537,5.0014391,621.63623};
 					};
 					side="East";
 					flags=4;
@@ -29064,7 +29206,7 @@ class Mission
 						description="Russian Foxtrot Squad Assistant Grenadier";
 						isPlayable=1;
 					};
-					id=1644;
+					id=2441;
 					type="potato_msv_ag";
 					class CustomAttributes
 					{
@@ -29095,7 +29237,7 @@ class Mission
 			{
 				name="GROUP_MSV_F";
 			};
-			id=1635;
+			id=2432;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29158,7 +29300,1455 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item155
+		class Item151
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=9;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={773.85956,5.0014391,626.11377};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						rank="SERGEANT";
+						name="UNIT_MSV_G_SL";
+						description="Russian Golf Squad Leader@Russian Golf Squad";
+						isPlayable=1;
+					};
+					id=2566;
+					type="potato_msv_sl";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={775.73553,5.0014391,625.94177};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_G_VG";
+						description="Russian Golf Squad Vehicle Gunner";
+						isPlayable=1;
+					};
+					id=2567;
+					type="potato_msv_vicc";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="YELLOW";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="potato_markers_addMarker";
+							expression="[_this,_value] call potato_markers_fnc_setMarker;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GV,32,red,\z\potato\addons\markers\data\mechanized_infantry.paa";
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={777.94751,5.0014391,626.00879};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_G_VD";
+						description="Russian Golf Squad Vehicle Driver";
+						isPlayable=1;
+					};
+					id=2568;
+					type="potato_msv_vicd";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="YELLOW";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={773.83252,5.0014391,623.88275};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_G_SR";
+						description="Russian Golf Squad Senior Rifleman";
+						isPlayable=1;
+					};
+					id=2569;
+					type="potato_msv_sr";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="potato_markers_addMarker";
+							expression="[_this,_value] call potato_markers_fnc_setMarker;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GSR,16,red,\z\potato\addons\markers\data\infantry.paa";
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={775.90454,5.0014391,624.0238};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_G_R";
+						description="Russian Golf Squad Rifleman";
+						isPlayable=1;
+					};
+					id=2570;
+					type="potato_msv_rifleman";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={777.79254,5.0014391,623.98376};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_G_M";
+						description="Russian Golf Squad Medic";
+						isPlayable=1;
+					};
+					id=2571;
+					type="potato_msv_sm";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="BLUE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="potato_markers_addMarker";
+							expression="[_this,_value] call potato_markers_fnc_setMarker;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GM,16,pink,\z\potato\addons\markers\data\medical.paa";
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={773.78156,5.0014391,622.01978};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_G_AR";
+						description="Russian Golf Squad Automatic Rifleman";
+						isPlayable=1;
+					};
+					id=2572;
+					type="potato_msv_ar";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="BLUE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={775.74054,5.0014391,621.96875};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_G_GR";
+						description="Russian Golf Squad Grenadier";
+						isPlayable=1;
+					};
+					id=2573;
+					type="potato_msv_g";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="RED";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={777.85352,5.0014391,621.97076};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_G_AGR";
+						description="Russian Golf Squad Assistant Grenadier";
+						isPlayable=1;
+					};
+					id=2574;
+					type="potato_msv_ag";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="RED";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="GROUP_MSV_G";
+			};
+			id=2565;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="potato_markers_addMarker";
+					expression="[_this,_value] call potato_markers_fnc_setMarker;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="G,24,red,\z\potato\addons\markers\data\infantry.paa";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="groupID";
+					expression="[_this, _value] call CBA_fnc_setCallsign";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="MSV Golf";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="potato_radios_radio";
+					expression="[_this,_value] call potato_radios_fnc_setChannels";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="8,2,2";
+						};
+					};
+				};
+				nAttributes=3;
+			};
+		};
+		class Item152
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=9;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={781.88342,5.0014391,625.94012};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						rank="SERGEANT";
+						name="UNIT_MSV_H_SL";
+						description="Russian Hotel Squad Leader@Russian Hotel Squad";
+						isPlayable=1;
+					};
+					id=2689;
+					type="potato_msv_sl";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={783.86139,5.0014391,625.89917};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_H_VG";
+						description="Russian Hotel Squad Vehicle Gunner";
+						isPlayable=1;
+					};
+					id=2690;
+					type="potato_msv_vicc";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="YELLOW";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="potato_markers_addMarker";
+							expression="[_this,_value] call potato_markers_fnc_setMarker;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="HV,32,blue,\z\potato\addons\markers\data\mechanized_infantry.paa";
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={785.8924,5.0014391,625.87115};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_H_VD";
+						description="Russian Hotel Squad Vehicle Driver";
+						isPlayable=1;
+					};
+					id=2691;
+					type="potato_msv_vicd";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="YELLOW";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={781.81641,5.0014391,623.82617};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_H_SR";
+						description="Russian Hotel Squad Senior Rifleman";
+						isPlayable=1;
+					};
+					id=2692;
+					type="potato_msv_sr";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="potato_markers_addMarker";
+							expression="[_this,_value] call potato_markers_fnc_setMarker;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="HSR,16,blue,\z\potato\addons\markers\data\infantry.paa";
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={783.9364,5.0014391,623.92212};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_H_MK";
+						description="Russian Hotel Squad Marksman";
+						isPlayable=1;
+					};
+					id=2693;
+					type="potato_msv_marksman";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={785.80243,5.0014391,623.89813};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_H_M";
+						description="Russian Hotel Squad Medic";
+						isPlayable=1;
+					};
+					id=2694;
+					type="potato_msv_sm";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="BLUE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="potato_markers_addMarker";
+							expression="[_this,_value] call potato_markers_fnc_setMarker;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="HM,16,pink,\z\potato\addons\markers\data\medical.paa";
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={781.8194,5.0014391,621.91217};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_H_AR";
+						description="Russian Hotel Squad Automatic Rifleman";
+						isPlayable=1;
+					};
+					id=2695;
+					type="potato_msv_ar";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="BLUE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={783.84039,5.0014391,621.83813};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_H_GR";
+						description="Russian Hotel Squad Grenadier";
+						isPlayable=1;
+					};
+					id=2696;
+					type="potato_msv_g";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="RED";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={785.96039,5.0014391,621.91016};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_H_AGR";
+						description="Russian Hotel Squad Assistant Grenadier";
+						isPlayable=1;
+					};
+					id=2697;
+					type="potato_msv_ag";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="RED";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="GROUP_MSV_H";
+			};
+			id=2688;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="potato_markers_addMarker";
+					expression="[_this,_value] call potato_markers_fnc_setMarker;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="H,24,blue,\z\potato\addons\markers\data\infantry.paa";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="groupID";
+					expression="[_this, _value] call CBA_fnc_setCallsign";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="MSV Hotel";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="potato_radios_radio";
+					expression="[_this,_value] call potato_radios_fnc_setChannels";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="9,2,2";
+						};
+					};
+				};
+				nAttributes=3;
+			};
+		};
+		class Item153
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=9;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={789.35516,5.0014391,625.97571};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						rank="SERGEANT";
+						name="UNIT_MSV_I_SL";
+						description="Russian India Squad Leader@Russian India Squad";
+						isPlayable=1;
+					};
+					id=2802;
+					type="potato_msv_sl";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={791.37012,5.0014391,625.90973};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_I_VG";
+						description="Russian India Squad Vehicle Gunner";
+						isPlayable=1;
+					};
+					id=2803;
+					type="potato_msv_vicc";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="YELLOW";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="potato_markers_addMarker";
+							expression="[_this,_value] call potato_markers_fnc_setMarker;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="IV,32,green,\z\potato\addons\markers\data\mechanized_infantry.paa";
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={793.38312,5.0014391,625.93671};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_I_VD";
+						description="Russian India Squad Vehicle Driver";
+						isPlayable=1;
+					};
+					id=2804;
+					type="potato_msv_vicd";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="YELLOW";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item3
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={789.30414,5.0014391,623.95972};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_I_SR";
+						description="Russian India Squad Senior Rifleman";
+						isPlayable=1;
+					};
+					id=2805;
+					type="potato_msv_sr";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="potato_markers_addMarker";
+							expression="[_this,_value] call potato_markers_fnc_setMarker;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="ISR,16,green,\z\potato\addons\markers\data\infantry.paa";
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item4
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={791.40515,5.0014391,623.96167};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_I_R";
+						description="Russian India Squad Rifleman";
+						isPlayable=1;
+					};
+					id=2806;
+					type="potato_msv_rifleman";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="GREEN";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item5
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={793.34113,5.0014391,623.87769};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_I_M";
+						description="Russian India Squad Medic";
+						isPlayable=1;
+					};
+					id=2807;
+					type="potato_msv_sm";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="BLUE";
+								};
+							};
+						};
+						class Attribute1
+						{
+							property="potato_markers_addMarker";
+							expression="[_this,_value] call potato_markers_fnc_setMarker;";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="IM,16,pink,\z\potato\addons\markers\data\medical.paa";
+								};
+							};
+						};
+						nAttributes=2;
+					};
+				};
+				class Item6
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={789.33014,5.0014391,621.88373};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_I_AR";
+						description="Russian India Squad Automatic Rifleman";
+						isPlayable=1;
+					};
+					id=2808;
+					type="potato_msv_ar";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="BLUE";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item7
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={791.38916,5.0014391,621.95172};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_I_GR";
+						description="Russian India Squad Grenadier";
+						isPlayable=1;
+					};
+					id=2809;
+					type="potato_msv_g";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="RED";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+				class Item8
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={793.39612,5.0014391,621.8927};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_I_AGR";
+						description="Russian India Squad Assistant Grenadier";
+						isPlayable=1;
+					};
+					id=2810;
+					type="potato_msv_ag";
+					class CustomAttributes
+					{
+						class Attribute0
+						{
+							property="potato_teamColors_teamColor";
+							expression="[_this,_value] call potato_teamColors_fnc_setColor";
+							class Value
+							{
+								class data
+								{
+									class type
+									{
+										type[]=
+										{
+											"STRING"
+										};
+									};
+									value="RED";
+								};
+							};
+						};
+						nAttributes=1;
+					};
+				};
+			};
+			class Attributes
+			{
+				name="GROUP_MSV_I";
+			};
+			id=2801;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="potato_markers_addMarker";
+					expression="[_this,_value] call potato_markers_fnc_setMarker;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="I,24,green,\z\potato\addons\markers\data\infantry.paa";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="groupID";
+					expression="[_this, _value] call CBA_fnc_setCallsign";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="MSV India";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="potato_radios_radio";
+					expression="[_this,_value] call potato_radios_fnc_setChannels";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="10,2,2";
+						};
+					};
+				};
+				nAttributes=3;
+			};
+		};
+		class Item154
 		{
 			dataType="Group";
 			side="East";
@@ -29170,7 +30760,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={761.25232,5.0014391,613.11572};
+						position[]={765.43799,5.0014391,616.409};
 					};
 					side="East";
 					flags=6;
@@ -29178,10 +30768,10 @@ class Mission
 					{
 						rank="LIEUTENANT";
 						name="UNIT_MSV_W_CO";
-						description="Russian Weapons Platoon Commander@Weapons Squad";
+						description="Russian Weapons Platoon Commander@Russian Weapons Platoon";
 						isPlayable=1;
 					};
-					id=1650;
+					id=2812;
 					type="potato_msv_plt";
 				};
 				class Item1
@@ -29189,7 +30779,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={757.52014,5.0014391,608.64618};
+						position[]={761.70551,5.0014391,611.93915};
 					};
 					side="East";
 					flags=4;
@@ -29200,7 +30790,7 @@ class Mission
 						description="Russian Weapons Platoon Assistant Leader";
 						isPlayable=1;
 					};
-					id=1649;
+					id=2813;
 					type="potato_msv_aplt";
 				};
 			};
@@ -29208,7 +30798,7 @@ class Mission
 			{
 				name="GROUP_MSV_W";
 			};
-			id=1648;
+			id=2811;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29245,7 +30835,119 @@ class Mission
 									"STRING"
 								};
 							};
-							value="MSV Weapons";
+							value="MSV WPLT";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="potato_radios_radio";
+					expression="[_this,_value] call potato_radios_fnc_setChannels";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="15,6,3";
+						};
+					};
+				};
+				nAttributes=3;
+			};
+		};
+		class Item155
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=2;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={767.97998,5.0014391,612.401};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_W1_VG";
+						description="Russian Weapon Vehicle Gunner 1@Russian Weapon Vehicle 1";
+						isPlayable=1;
+					};
+					id=2815;
+					type="potato_msv_vicc";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={772.26703,5.0014391,606.82898};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_W1_VD";
+						description="Russian Weapon Vehicle Driver 1";
+						isPlayable=1;
+					};
+					id=2816;
+					type="potato_msv_vicd";
+				};
+			};
+			class Attributes
+			{
+				name="GROUP_W_VIC1";
+			};
+			id=2814;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="potato_markers_addMarker";
+					expression="[_this,_value] call potato_markers_fnc_setMarker;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="WV1,32,orange,\z\potato\addons\markers\data\mechanized_infantry.paa";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="groupID";
+					expression="[_this, _value] call CBA_fnc_setCallsign";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="MSV WV1";
 						};
 					};
 				};
@@ -29283,18 +30985,18 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={763.79456,5.0014391,609.1084};
+						position[]={767.505,5.0014391,607.26599};
 					};
 					side="East";
 					flags=6;
 					class Attributes
 					{
 						rank="CORPORAL";
-						name="UNIT_MSV_W1_VG";
-						description="Russian Weapon Squad Vehicle Gunner 1";
+						name="UNIT_MSV_W2_VG";
+						description="Russian Weapon Vehicle Gunner 2@Russian Weapon Vehicle 2";
 						isPlayable=1;
 					};
-					id=1657;
+					id=2818;
 					type="potato_msv_vicc";
 				};
 				class Item1
@@ -29302,25 +31004,25 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={768.08173,5.0014391,603.53558};
+						position[]={771.79199,5.0014391,601.69299};
 					};
 					side="East";
 					flags=4;
 					class Attributes
 					{
-						name="UNIT_MSV_W1_VD";
-						description="Russian Weapon Squad Vehicle Driver 1";
+						name="UNIT_MSV_W2_VD";
+						description="Russian Weapon Vehicle Driver 2";
 						isPlayable=1;
 					};
-					id=1658;
-					type="potato_msv_vicd";
+					id=2819;
+					type="potato_msv_vicc";
 				};
 			};
 			class Attributes
 			{
-				name="GROUP_W_VIC1";
+				name="GROUP_W_VIC2";
 			};
-			id=1656;
+			id=2817;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29338,7 +31040,7 @@ class Mission
 									"STRING"
 								};
 							};
-							value="WV1,32,orange,\z\potato\addons\markers\data\mechanized_infantry.paa";
+							value="WV2,32,orange,\z\potato\addons\markers\data\mechanized_infantry.paa";
 						};
 					};
 				};
@@ -29357,7 +31059,7 @@ class Mission
 									"STRING"
 								};
 							};
-							value="MSV Weapons Vehicle 1";
+							value="MSV WV2";
 						};
 					};
 				};
@@ -29395,18 +31097,18 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={763.31976,5.0014391,603.97333};
+						position[]={767.23499,5.0014391,603.32397};
 					};
 					side="East";
 					flags=6;
 					class Attributes
 					{
 						rank="CORPORAL";
-						name="UNIT_MSV_W2_VG";
-						description="Russian Weapon Squad Vehicle Gunner 2";
+						name="UNIT_MSV_W3_VG";
+						description="Russian Weapon Vehicle Gunner 3@Russian Weapon Vehicle 3";
 						isPlayable=1;
 					};
-					id=1663;
+					id=2821;
 					type="potato_msv_vicc";
 				};
 				class Item1
@@ -29414,25 +31116,25 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={767.60693,5.0014391,598.40051};
+						position[]={771.52197,5.0014391,597.75098};
 					};
 					side="East";
 					flags=4;
 					class Attributes
 					{
-						name="UNIT_MSV_W2_VD";
-						description="Russian Weapon Squad Vehicle Driver 2";
+						name="UNIT_MSV_W3_VD";
+						description="Russian Weapon Vehicle Driver 3";
 						isPlayable=1;
 					};
-					id=1664;
+					id=2822;
 					type="potato_msv_vicc";
 				};
 			};
 			class Attributes
 			{
-				name="GROUP_W_VIC2";
+				name="GROUP_W_VIC3";
 			};
-			id=1662;
+			id=2820;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29450,7 +31152,7 @@ class Mission
 									"STRING"
 								};
 							};
-							value="WV2,32,orange,\z\potato\addons\markers\data\mechanized_infantry.paa";
+							value="WV3,32,orange,\z\potato\addons\markers\data\mechanized_infantry.paa";
 						};
 					};
 				};
@@ -29469,7 +31171,7 @@ class Mission
 									"STRING"
 								};
 							};
-							value="MSV Weapons Vehicle 2";
+							value="MSV WV3";
 						};
 					};
 				};
@@ -29507,119 +31209,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={763.04932,5.0014391,600.03131};
-					};
-					side="East";
-					flags=6;
-					class Attributes
-					{
-						rank="CORPORAL";
-						name="UNIT_MSV_W3_VG";
-						description="Russian Weapon Squad Vehicle Gunner 3";
-						isPlayable=1;
-					};
-					id=1673;
-					type="potato_msv_vicc";
-				};
-				class Item1
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={767.33649,5.0014391,594.45844};
-					};
-					side="East";
-					flags=4;
-					class Attributes
-					{
-						name="UNIT_MSV_W3_VD";
-						description="Russian Weapon Squad Vehicle Driver 3";
-						isPlayable=1;
-					};
-					id=1674;
-					type="potato_msv_vicc";
-				};
-			};
-			class Attributes
-			{
-				name="GROUP_W_VIC3";
-			};
-			id=1672;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="potato_markers_addMarker";
-					expression="[_this,_value] call potato_markers_fnc_setMarker;";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="WV3,32,orange,\z\potato\addons\markers\data\mechanized_infantry.paa";
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="groupID";
-					expression="[_this, _value] call CBA_fnc_setCallsign";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="MSV Weapons Vehicle 3";
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="potato_radios_radio";
-					expression="[_this,_value] call potato_radios_fnc_setChannels";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="15,6,3";
-						};
-					};
-				};
-				nAttributes=3;
-			};
-		};
-		class Item159
-		{
-			dataType="Group";
-			side="East";
-			class Entities
-			{
-				items=2;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={753.47076,5.0014391,604.92487};
+						position[]={757.65613,5.0014391,608.21783};
 					};
 					side="East";
 					flags=6;
@@ -29627,10 +31217,10 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_MSV_MMG1_G";
-						description="Russian Machine Gunner@MG Team 1";
+						description="Russian Machine Gunner@Russian MG Team 1";
 						isPlayable=1;
 					};
-					id=1682;
+					id=2824;
 					type="potato_msv_mmgg";
 				};
 				class Item1
@@ -29638,7 +31228,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={758.47595,5.0014391,599.98706};
+						position[]={762.66132,5.0014391,603.28003};
 					};
 					side="East";
 					flags=4;
@@ -29648,7 +31238,7 @@ class Mission
 						description="Russian Machine Gunner Assistant";
 						isPlayable=1;
 					};
-					id=1683;
+					id=2825;
 					type="potato_msv_mmgag";
 				};
 			};
@@ -29656,7 +31246,7 @@ class Mission
 			{
 				name="GROUP_MSV_MMG1";
 			};
-			id=1681;
+			id=2823;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29719,7 +31309,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item160
+		class Item159
 		{
 			dataType="Group";
 			side="East";
@@ -29731,7 +31321,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={753.46088,5.0014391,600.6709};
+						position[]={757.64624,5.0014391,603.96387};
 					};
 					side="East";
 					flags=6;
@@ -29739,10 +31329,10 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_MSV_MMG2_G";
-						description="Russian Machine Gunner@MG Team 2";
+						description="Russian Machine Gunner@Russian MG Team 2";
 						isPlayable=1;
 					};
-					id=1685;
+					id=2827;
 					type="potato_msv_mmgg";
 				};
 				class Item1
@@ -29750,7 +31340,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={758.46606,5.0014391,595.73303};
+						position[]={762.65143,5.0014391,599.026};
 					};
 					side="East";
 					flags=4;
@@ -29760,7 +31350,7 @@ class Mission
 						description="Russian Machine Gunner Assistant";
 						isPlayable=1;
 					};
-					id=1686;
+					id=2828;
 					type="potato_msv_mmgag";
 				};
 			};
@@ -29768,7 +31358,7 @@ class Mission
 			{
 				name="GROUP_MSV_MMG2";
 			};
-			id=1684;
+			id=2826;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29831,7 +31421,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item161
+		class Item160
 		{
 			dataType="Group";
 			side="East";
@@ -29843,7 +31433,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={753.34802,5.0014391,597.83984};
+						position[]={757.53302,5.0014391,601.133};
 					};
 					side="East";
 					flags=6;
@@ -29851,10 +31441,10 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_MSV_MMG3_G";
-						description="Russian Machine Gunner";
+						description="Russian Machine Gunner@Russian MG Team 3";
 						isPlayable=1;
 					};
-					id=1688;
+					id=2830;
 					type="potato_msv_mmgg";
 				};
 				class Item1
@@ -29862,7 +31452,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={758.35321,5.0014391,592.90204};
+						position[]={762.53857,5.0014391,596.19501};
 					};
 					side="East";
 					flags=4;
@@ -29872,7 +31462,7 @@ class Mission
 						description="Russian Machine Gunner Assistant";
 						isPlayable=1;
 					};
-					id=1689;
+					id=2831;
 					type="potato_msv_mmgag";
 				};
 			};
@@ -29880,7 +31470,7 @@ class Mission
 			{
 				name="GROUP_MSV_MMG3";
 			};
-			id=1687;
+			id=2829;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -29943,7 +31533,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item162
+		class Item161
 		{
 			dataType="Group";
 			side="East";
@@ -29955,7 +31545,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={745.33954,5.0014391,607.05109};
+						position[]={749.5249,5.0014391,610.34406};
 					};
 					side="East";
 					flags=6;
@@ -29963,10 +31553,10 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_MSV_MAT1_G";
-						description="Russian ATGM Operator@MAT Team 1";
+						description="Russian ATGM Operator@Russian MAT Team 1";
 						isPlayable=1;
 					};
-					id=1698;
+					id=2833;
 					type="potato_msv_matg";
 				};
 				class Item1
@@ -29974,7 +31564,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={750.26373,5.0014391,602.03223};
+						position[]={754.4491,5.0014391,605.3252};
 					};
 					side="East";
 					flags=4;
@@ -29984,7 +31574,7 @@ class Mission
 						description="Russian ATGM Assistant";
 						isPlayable=1;
 					};
-					id=1699;
+					id=2834;
 					type="potato_msv_matag";
 				};
 			};
@@ -29992,7 +31582,7 @@ class Mission
 			{
 				name="GROUP_MSV_MAT1";
 			};
-			id=1697;
+			id=2832;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -30055,7 +31645,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item163
+		class Item162
 		{
 			dataType="Group";
 			side="East";
@@ -30067,7 +31657,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={745.18274,5.0014391,602.32605};
+						position[]={749.3681,5.0014391,605.61902};
 					};
 					side="East";
 					flags=6;
@@ -30075,10 +31665,10 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_MSV_MAT2_G";
-						description="Russian ATGM Operator@MAT Team 2";
+						description="Russian ATGM Operator@Russian MAT Team 2";
 						isPlayable=1;
 					};
-					id=1701;
+					id=2836;
 					type="potato_msv_matg";
 				};
 				class Item1
@@ -30086,7 +31676,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={750.10797,5.0014391,597.30823};
+						position[]={754.29333,5.0014391,600.6012};
 					};
 					side="East";
 					flags=4;
@@ -30096,7 +31686,7 @@ class Mission
 						description="Russian ATGM Assistant";
 						isPlayable=1;
 					};
-					id=1702;
+					id=2837;
 					type="potato_msv_matag";
 				};
 			};
@@ -30104,7 +31694,7 @@ class Mission
 			{
 				name="GROUP_MSV_MAT2";
 			};
-			id=1700;
+			id=2835;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -30167,7 +31757,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item164
+		class Item163
 		{
 			dataType="Group";
 			side="East";
@@ -30179,7 +31769,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={745.19385,5.0014391,599.04706};
+						position[]={749.37921,5.0014391,602.34003};
 					};
 					side="East";
 					flags=6;
@@ -30187,10 +31777,10 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_MSV_MAT3_G";
-						description="Russian ATGM Operator@MAT Team 3";
+						description="Russian ATGM Operator@Russian MAT Team 3";
 						isPlayable=1;
 					};
-					id=1704;
+					id=2839;
 					type="potato_msv_matg";
 				};
 				class Item1
@@ -30198,7 +31788,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={750.11804,5.0014391,594.02924};
+						position[]={754.30341,5.0014391,597.3222};
 					};
 					side="East";
 					flags=4;
@@ -30208,7 +31798,7 @@ class Mission
 						description="Russian ATGM Assistant";
 						isPlayable=1;
 					};
-					id=1705;
+					id=2840;
 					type="potato_msv_matag";
 				};
 			};
@@ -30216,7 +31806,7 @@ class Mission
 			{
 				name="GROUP_MSV_MAT3";
 			};
-			id=1703;
+			id=2838;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -30279,7 +31869,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item165
+		class Item164
 		{
 			dataType="Group";
 			side="East";
@@ -30291,7 +31881,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={732.70813,5.0014391,606.45215};
+						position[]={736.89349,5.0014391,609.74512};
 					};
 					side="East";
 					flags=6;
@@ -30299,10 +31889,10 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_MSV_MSAM_L";
-						description="Russian MSAM Leader@Medium SAM Team";
+						description="Russian MSAM Leader@Russian Medium SAM Team";
 						isPlayable=1;
 					};
-					id=1712;
+					id=2842;
 					type="potato_msv_msaml";
 				};
 				class Item1
@@ -30310,7 +31900,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={737.6391,5.0014391,601.43414};
+						position[]={741.82446,5.0014391,604.72711};
 					};
 					side="East";
 					flags=4;
@@ -30320,7 +31910,7 @@ class Mission
 						description="Russian MSAM Gunner";
 						isPlayable=1;
 					};
-					id=1713;
+					id=2843;
 					type="potato_msv_msamg";
 				};
 				class Item2
@@ -30328,7 +31918,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={727.64008,5.0014391,601.57111};
+						position[]={731.82544,5.0014391,604.86407};
 					};
 					side="East";
 					flags=4;
@@ -30338,7 +31928,7 @@ class Mission
 						description="Russian MSAM Gunner";
 						isPlayable=1;
 					};
-					id=1714;
+					id=2844;
 					type="potato_msv_msamg";
 				};
 				class Item3
@@ -30346,7 +31936,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={742.57019,5.0014391,596.36609};
+						position[]={746.75555,5.0014391,599.65906};
 					};
 					side="East";
 					flags=4;
@@ -30357,7 +31947,7 @@ class Mission
 						description="Russian MSAM Assistant";
 						isPlayable=1;
 					};
-					id=1715;
+					id=2845;
 					type="potato_msv_msamag";
 				};
 			};
@@ -30365,7 +31955,7 @@ class Mission
 			{
 				name="GROUP_MSV_MSAM";
 			};
-			id=1706;
+			id=2841;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -30428,7 +32018,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item166
+		class Item165
 		{
 			dataType="Group";
 			side="East";
@@ -30440,7 +32030,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={746.01416,5.0014391,595.51965};
+						position[]={750.19952,5.0014391,598.81262};
 					};
 					side="East";
 					flags=6;
@@ -30448,10 +32038,10 @@ class Mission
 					{
 						rank="CORPORAL";
 						name="UNIT_MSV_ENG1_FTL";
-						description="Russian Engineer Team 1 Leader@Engineer Team";
+						description="Russian Engineer Team 1 Leader@Russian Engineer Team";
 						isPlayable=1;
 					};
-					id=1732;
+					id=2847;
 					type="potato_msv_engl";
 				};
 				class Item1
@@ -30459,7 +32049,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={740.98035,5.0014391,590.60352};
+						position[]={745.16571,5.0014391,593.89648};
 					};
 					side="East";
 					flags=4;
@@ -30469,7 +32059,7 @@ class Mission
 						description="Russian Engineer Team 1 Assistant";
 						isPlayable=1;
 					};
-					id=1733;
+					id=2848;
 					type="potato_msv_eng";
 				};
 				class Item2
@@ -30477,7 +32067,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={750.98035,5.0014391,590.53687};
+						position[]={755.16571,5.0014391,593.82983};
 					};
 					side="East";
 					flags=4;
@@ -30487,7 +32077,7 @@ class Mission
 						description="Russian Engineer Team 1 Assistant";
 						isPlayable=1;
 					};
-					id=1734;
+					id=2849;
 					type="potato_msv_eng";
 				};
 				class Item3
@@ -30495,7 +32085,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={755.94653,5.0014391,585.50305};
+						position[]={760.1319,5.0014391,588.79602};
 					};
 					side="East";
 					flags=4;
@@ -30505,7 +32095,7 @@ class Mission
 						description="Russian Engineer Team 1 Assistant";
 						isPlayable=1;
 					};
-					id=1735;
+					id=2850;
 					type="potato_msv_eng";
 				};
 			};
@@ -30513,7 +32103,7 @@ class Mission
 			{
 				name="GROUP_MSV_ENG1";
 			};
-			id=1727;
+			id=2846;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -30550,7 +32140,7 @@ class Mission
 									"STRING"
 								};
 							};
-							value="MSV Engineers";
+							value="MSV ENG1";
 						};
 					};
 				};
@@ -30576,7 +32166,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item167
+		class Item166
 		{
 			dataType="Group";
 			side="East";
@@ -30588,7 +32178,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={733.263,5.0014391,598.22778};
+						position[]={737.44836,5.0014391,601.52075};
 					};
 					side="East";
 					flags=6;
@@ -30596,10 +32186,10 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_MSV_TNK1_C";
-						description="Russian Tank 1 Commander@Tank 1";
+						description="Russian Tank 1 Commander@Russian Tank 1";
 						isPlayable=1;
 					};
-					id=1766;
+					id=2852;
 					type="potato_msv_vicl";
 				};
 				class Item1
@@ -30607,7 +32197,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={738.41412,5.0014391,593.43402};
+						position[]={742.59949,5.0014391,596.72699};
 					};
 					side="East";
 					flags=4;
@@ -30618,7 +32208,7 @@ class Mission
 						description="Russian Tank 1 Gunner";
 						isPlayable=1;
 					};
-					id=1767;
+					id=2853;
 					type="potato_msv_vicc";
 				};
 				class Item2
@@ -30626,7 +32216,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={728.41821,5.0014391,593.12665};
+						position[]={732.60358,5.0014391,596.41962};
 					};
 					side="East";
 					flags=4;
@@ -30636,7 +32226,7 @@ class Mission
 						description="Russian Tank 1 Driver (Repair)";
 						isPlayable=1;
 					};
-					id=1768;
+					id=2854;
 					type="potato_msv_vicd";
 				};
 			};
@@ -30644,7 +32234,7 @@ class Mission
 			{
 				name="GROUP_MSV_TANK1";
 			};
-			id=1750;
+			id=2851;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -30681,7 +32271,138 @@ class Mission
 									"STRING"
 								};
 							};
-							value="MSV Tank1";
+							value="MSV TNK1";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="potato_radios_radio";
+					expression="[_this,_value] call potato_radios_fnc_setChannels";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="14,5,3";
+						};
+					};
+				};
+				nAttributes=3;
+			};
+		};
+		class Item167
+		{
+			dataType="Group";
+			side="East";
+			class Entities
+			{
+				items=3;
+				class Item0
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={737.60724,5.0014391,599.61145};
+					};
+					side="East";
+					flags=6;
+					class Attributes
+					{
+						rank="SERGEANT";
+						name="UNIT_MSV_TNK2_C";
+						description="Russian Tank 2 Commander@Russian Tank 2";
+						isPlayable=1;
+					};
+					id=2856;
+					type="potato_msv_vicl";
+				};
+				class Item1
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={742.75885,5.0014391,594.81757};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						rank="CORPORAL";
+						name="UNIT_MSV_TNK2_G";
+						description="Russian Tank 2 Gunner";
+						isPlayable=1;
+					};
+					id=2857;
+					type="potato_msv_vicc";
+				};
+				class Item2
+				{
+					dataType="Object";
+					class PositionInfo
+					{
+						position[]={732.76282,5.0014391,594.51019};
+					};
+					side="East";
+					flags=4;
+					class Attributes
+					{
+						name="UNIT_MSV_TNK2_D";
+						description="Russian Tank 2 Driver (Repair)";
+						isPlayable=1;
+					};
+					id=2858;
+					type="potato_msv_vicd";
+				};
+			};
+			class Attributes
+			{
+				name="GROUP_MSV_TANK2";
+			};
+			id=2855;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="potato_markers_addMarker";
+					expression="[_this,_value] call potato_markers_fnc_setMarker;";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="TANK2,32,blue,\z\potato\addons\markers\data\armor.paa";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="groupID";
+					expression="[_this, _value] call CBA_fnc_setCallsign";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="MSV TNK2";
 						};
 					};
 				};
@@ -30719,18 +32440,18 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={733.42188,5.0014391,596.31848};
+						position[]={737.66516,5.0014391,598.02802};
 					};
 					side="East";
 					flags=6;
 					class Attributes
 					{
 						rank="SERGEANT";
-						name="UNIT_MSV_TNK2_C";
-						description="Russian Tank 2 Commander@Tank 2";
+						name="UNIT_MSV_TNK3_C";
+						description="Russian Tank 3 Commander@Russian Tank 3";
 						isPlayable=1;
 					};
-					id=1785;
+					id=2860;
 					type="potato_msv_vicl";
 				};
 				class Item1
@@ -30738,18 +32459,18 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={738.57349,5.0014391,591.5246};
+						position[]={742.73236,5.0014391,593.14496};
 					};
 					side="East";
 					flags=4;
 					class Attributes
 					{
 						rank="CORPORAL";
-						name="UNIT_MSV_TNK2_G";
-						description="Russian Tank 2 Gunner";
+						name="UNIT_MSV_TNK3_G";
+						description="Russian Tank 3 Gunner";
 						isPlayable=1;
 					};
-					id=1786;
+					id=2861;
 					type="potato_msv_vicc";
 				};
 				class Item2
@@ -30757,25 +32478,25 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={728.57745,5.0014391,591.21722};
+						position[]={732.73236,5.0014391,593.01257};
 					};
 					side="East";
 					flags=4;
 					class Attributes
 					{
-						name="UNIT_MSV_TNK2_D";
-						description="Russian Tank 2 Driver (Repair)";
+						name="UNIT_MSV_TNK3_D";
+						description="Russian Tank 3 Driver (Repair)";
 						isPlayable=1;
 					};
-					id=1787;
+					id=2862;
 					type="potato_msv_vicd";
 				};
 			};
 			class Attributes
 			{
-				name="GROUP_MSV_TANK2";
+				name="GROUP_MSV_TANK3";
 			};
-			id=1784;
+			id=2859;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -30793,7 +32514,7 @@ class Mission
 									"STRING"
 								};
 							};
-							value="TANK2,32,blue,\z\potato\addons\markers\data\armor.paa";
+							value="TANK3,32,red,\z\potato\addons\markers\data\armor.paa";
 						};
 					};
 				};
@@ -30812,7 +32533,7 @@ class Mission
 									"STRING"
 								};
 							};
-							value="MSV Tank2";
+							value="MSV TNK3";
 						};
 					};
 				};
@@ -30850,138 +32571,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={733.4798,5.0014391,594.73505};
-					};
-					side="East";
-					flags=6;
-					class Attributes
-					{
-						rank="SERGEANT";
-						name="UNIT_MSV_TNK3_C";
-						description="Russian Tank 3 Commander@Tank 3";
-						isPlayable=1;
-					};
-					id=1789;
-					type="potato_msv_vicl";
-				};
-				class Item1
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={738.547,5.0014391,589.85199};
-					};
-					side="East";
-					flags=4;
-					class Attributes
-					{
-						rank="CORPORAL";
-						name="UNIT_MSV_TNK3_G";
-						description="Russian Tank 3 Gunner";
-						isPlayable=1;
-					};
-					id=1790;
-					type="potato_msv_vicc";
-				};
-				class Item2
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={728.547,5.0014391,589.7196};
-					};
-					side="East";
-					flags=4;
-					class Attributes
-					{
-						name="UNIT_MSV_TNK3_D";
-						description="Russian Tank 3 Driver (Repair)";
-						isPlayable=1;
-					};
-					id=1791;
-					type="potato_msv_vicd";
-				};
-			};
-			class Attributes
-			{
-				name="GROUP_MSV_TANK3";
-			};
-			id=1788;
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="potato_markers_addMarker";
-					expression="[_this,_value] call potato_markers_fnc_setMarker;";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="TANK3,32,red,\z\potato\addons\markers\data\armor.paa";
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="groupID";
-					expression="[_this, _value] call CBA_fnc_setCallsign";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="MSV Tank3";
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="potato_radios_radio";
-					expression="[_this,_value] call potato_radios_fnc_setChannels";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"STRING"
-								};
-							};
-							value="14,5,3";
-						};
-					};
-				};
-				nAttributes=3;
-			};
-		};
-		class Item170
-		{
-			dataType="Group";
-			side="East";
-			class Entities
-			{
-				items=3;
-				class Item0
-				{
-					dataType="Object";
-					class PositionInfo
-					{
-						position[]={733.56079,5.0014391,593.38202};
+						position[]={737.74615,5.0014391,596.67499};
 					};
 					side="East";
 					flags=6;
@@ -30989,10 +32579,10 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_MSV_TNK4_C";
-						description="Russian Tank 4 Commander@Tank 4";
+						description="Russian Tank 4 Commander@Russian Tank 4";
 						isPlayable=1;
 					};
-					id=1793;
+					id=2864;
 					type="potato_msv_vicl";
 				};
 				class Item1
@@ -31000,7 +32590,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={738.62695,5.0014391,588.49921};
+						position[]={742.81232,5.0014391,591.79218};
 					};
 					side="East";
 					flags=4;
@@ -31011,7 +32601,7 @@ class Mission
 						description="Russian Tank 4 Gunner";
 						isPlayable=1;
 					};
-					id=1794;
+					id=2865;
 					type="potato_msv_vicc";
 				};
 				class Item2
@@ -31019,7 +32609,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={728.62695,5.0014391,588.36688};
+						position[]={732.81232,5.0014391,591.65985};
 					};
 					side="East";
 					flags=4;
@@ -31029,7 +32619,7 @@ class Mission
 						description="Russian Tank 4 Driver (Repair)";
 						isPlayable=1;
 					};
-					id=1795;
+					id=2866;
 					type="potato_msv_vicd";
 				};
 			};
@@ -31037,7 +32627,7 @@ class Mission
 			{
 				name="GROUP_MSV_TANK4";
 			};
-			id=1792;
+			id=2863;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -31074,7 +32664,7 @@ class Mission
 									"STRING"
 								};
 							};
-							value="MSV Tank4";
+							value="MSV TNK4";
 						};
 					};
 				};
@@ -31100,7 +32690,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item171
+		class Item170
 		{
 			dataType="Group";
 			side="East";
@@ -31112,7 +32702,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={759.93054,5.0014391,587.13745};
+						position[]={764.11591,5.0014391,590.43042};
 					};
 					side="East";
 					flags=6;
@@ -31120,10 +32710,10 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_MSV_TH1_P";
-						description="Russian Transport Helo 1 Pilot@Heli Transport 1";
+						description="Russian Transport Helo 1 Pilot@Russian Heli Transport 1";
 						isPlayable=1;
 					};
-					id=1799;
+					id=2868;
 					type="potato_msv_pilot";
 					class CustomAttributes
 					{
@@ -31154,7 +32744,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={765.05273,5.0014391,582.31262};
+						position[]={769.2381,5.0014391,585.60559};
 					};
 					side="East";
 					flags=4;
@@ -31165,7 +32755,7 @@ class Mission
 						description="Russian Transport Helo 1 Co-Pilot (Repair)";
 						isPlayable=1;
 					};
-					id=1800;
+					id=2869;
 					type="potato_msv_cc";
 				};
 			};
@@ -31173,7 +32763,7 @@ class Mission
 			{
 				name="GROUP_MSV_TH1";
 			};
-			id=1798;
+			id=2867;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -31217,7 +32807,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item172
+		class Item171
 		{
 			dataType="Group";
 			side="East";
@@ -31229,7 +32819,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={761.9588,5.0014391,587.05292};
+						position[]={766.14417,5.0014391,590.34589};
 					};
 					side="East";
 					flags=6;
@@ -31237,10 +32827,10 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_MSV_TH2_P";
-						description="Russian Transport Helo 2 Pilot@Heli Transport 2";
+						description="Russian Transport Helo 2 Pilot@Russian Heli Transport 2";
 						isPlayable=1;
 					};
-					id=1802;
+					id=2871;
 					type="potato_msv_pilot";
 					class CustomAttributes
 					{
@@ -31271,7 +32861,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={767.08105,5.0014391,582.22809};
+						position[]={771.26642,5.0014391,585.52106};
 					};
 					side="East";
 					flags=4;
@@ -31282,7 +32872,7 @@ class Mission
 						description="Russian Transport Helo 2 Co-Pilot (Repair)";
 						isPlayable=1;
 					};
-					id=1803;
+					id=2872;
 					type="potato_msv_cc";
 				};
 			};
@@ -31290,7 +32880,7 @@ class Mission
 			{
 				name="GROUP_MSV_TH2";
 			};
-			id=1801;
+			id=2870;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -31334,7 +32924,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item173
+		class Item172
 		{
 			dataType="Group";
 			side="East";
@@ -31346,7 +32936,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={763.97198,5.0014391,587.17542};
+						position[]={768.15735,5.0014391,590.46838};
 					};
 					side="East";
 					flags=6;
@@ -31354,10 +32944,10 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_MSV_TH3_P";
-						description="Russian Transport Helo 3 Pilot@Heli Transport 3";
+						description="Russian Transport Helo 3 Pilot@Russian Heli Transport 3";
 						isPlayable=1;
 					};
-					id=1805;
+					id=2874;
 					type="potato_msv_pilot";
 					class CustomAttributes
 					{
@@ -31388,7 +32978,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={769.09412,5.0014391,582.35065};
+						position[]={773.27948,5.0014391,585.64362};
 					};
 					side="East";
 					flags=4;
@@ -31399,7 +32989,7 @@ class Mission
 						description="Russian Transport Helo 3 Co-Pilot (Repair)";
 						isPlayable=1;
 					};
-					id=1806;
+					id=2875;
 					type="potato_msv_cc";
 				};
 			};
@@ -31407,7 +32997,7 @@ class Mission
 			{
 				name="GROUP_MSV_TH3";
 			};
-			id=1804;
+			id=2873;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -31451,7 +33041,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item174
+		class Item173
 		{
 			dataType="Group";
 			side="East";
@@ -31463,7 +33053,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={765.90094,5.0014391,587.18457};
+						position[]={770.0863,5.0014391,590.47754};
 					};
 					side="East";
 					flags=6;
@@ -31471,10 +33061,10 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_MSV_TH4_P";
-						description="Russian Transport Helo 4 Pilot@Heli Transport 4";
+						description="Russian Transport Helo 4 Pilot@Russian Heli Transport 4";
 						isPlayable=1;
 					};
-					id=1808;
+					id=2877;
 					type="potato_msv_pilot";
 					class CustomAttributes
 					{
@@ -31505,7 +33095,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={771.02319,5.0014391,582.35974};
+						position[]={775.20856,5.0014391,585.65271};
 					};
 					side="East";
 					flags=4;
@@ -31516,7 +33106,7 @@ class Mission
 						description="Russian Transport Helo 4 Co-Pilot (Repair)";
 						isPlayable=1;
 					};
-					id=1809;
+					id=2878;
 					type="potato_msv_cc";
 				};
 			};
@@ -31524,7 +33114,7 @@ class Mission
 			{
 				name="GROUP_MSV_TH4";
 			};
-			id=1807;
+			id=2876;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -31568,7 +33158,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item175
+		class Item174
 		{
 			dataType="Group";
 			side="East";
@@ -31580,7 +33170,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={768.01691,5.0014391,587.22461};
+						position[]={772.20227,5.0014391,590.51758};
 					};
 					side="East";
 					flags=6;
@@ -31588,10 +33178,10 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_MSV_AH1_P";
-						description="Russian Attack Helo 1 Pilot@Attack Heli 1";
+						description="Russian Attack Helo 1 Pilot@Russian Attack Heli 1";
 						isPlayable=1;
 					};
-					id=1813;
+					id=2880;
 					type="potato_msv_pilot";
 					class CustomAttributes
 					{
@@ -31622,7 +33212,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={773.10913,5.0014391,582.3678};
+						position[]={777.29449,5.0014391,585.66077};
 					};
 					side="East";
 					flags=4;
@@ -31633,7 +33223,7 @@ class Mission
 						description="Russian Attack Helo 1 Gunner (Repair)";
 						isPlayable=1;
 					};
-					id=1814;
+					id=2881;
 					type="potato_msv_cc";
 				};
 			};
@@ -31641,7 +33231,7 @@ class Mission
 			{
 				name="GROUP_MSV_AH1";
 			};
-			id=1810;
+			id=2879;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -31685,7 +33275,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item176
+		class Item175
 		{
 			dataType="Group";
 			side="East";
@@ -31697,7 +33287,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={769.97894,5.0014391,587.08868};
+						position[]={774.16431,5.0014391,590.38165};
 					};
 					side="East";
 					flags=6;
@@ -31705,10 +33295,10 @@ class Mission
 					{
 						rank="CAPTAIN";
 						name="UNIT_MSV_AH2_P";
-						description="Russian Attack Helo 2 Pilot@Attack Heli 2";
+						description="Russian Attack Helo 2 Pilot@Russian Attack Heli 2";
 						isPlayable=1;
 					};
-					id=1816;
+					id=2883;
 					type="potato_msv_pilot";
 					class CustomAttributes
 					{
@@ -31739,7 +33329,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={775.07117,5.0014391,582.23187};
+						position[]={779.25653,5.0014391,585.52484};
 					};
 					side="East";
 					flags=4;
@@ -31750,7 +33340,7 @@ class Mission
 						description="Russian Attack Helo 2 Gunner (Repair)";
 						isPlayable=1;
 					};
-					id=1817;
+					id=2884;
 					type="potato_msv_cc";
 				};
 			};
@@ -31758,7 +33348,7 @@ class Mission
 			{
 				name="GROUP_MSV_AH2";
 			};
-			id=1815;
+			id=2882;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -31802,7 +33392,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item177
+		class Item176
 		{
 			dataType="Group";
 			side="East";
@@ -31814,7 +33404,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={719.815,5.0014391,596.90106};
+						position[]={724.00037,5.0014391,600.19403};
 					};
 					side="East";
 					flags=6;
@@ -31822,10 +33412,10 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_MSV_SF_SL";
-						description="Russian Spetsnaz Leader@Spetsnaz";
+						description="Russian Spetsnaz Leader@Russian Spetsnaz";
 						isPlayable=1;
 					};
-					id=1834;
+					id=2886;
 					type="potato_msv_sf_sl";
 				};
 				class Item1
@@ -31833,7 +33423,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={723.90399,5.0014391,596.849};
+						position[]={728.08936,5.0014391,600.14197};
 					};
 					side="East";
 					flags=4;
@@ -31844,7 +33434,7 @@ class Mission
 						description="Russian Spetsnaz Rifleman";
 						isPlayable=1;
 					};
-					id=1836;
+					id=2887;
 					type="potato_msv_sf_rifleman";
 					class CustomAttributes
 					{
@@ -31875,7 +33465,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={719.81598,5.0014391,594.66986};
+						position[]={724.00134,5.0014391,597.96283};
 					};
 					side="East";
 					flags=4;
@@ -31885,7 +33475,7 @@ class Mission
 						description="Russian Spetsnaz Senior Rifleman";
 						isPlayable=1;
 					};
-					id=1837;
+					id=2888;
 					type="potato_msv_sf_ftl";
 					class CustomAttributes
 					{
@@ -31916,7 +33506,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={721.88599,5.0014391,594.83771};
+						position[]={726.07135,5.0014391,598.13068};
 					};
 					side="East";
 					flags=4;
@@ -31927,7 +33517,7 @@ class Mission
 						description="Russian Spetsnaz Marksman";
 						isPlayable=1;
 					};
-					id=1841;
+					id=2889;
 					type="potato_msv_sf_marksman";
 				};
 				class Item4
@@ -31935,7 +33525,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={721.69299,5.0014391,596.75299};
+						position[]={725.87836,5.0014391,600.04596};
 					};
 					side="East";
 					flags=4;
@@ -31946,7 +33536,7 @@ class Mission
 						description="Russian Spetsnaz Medic";
 						isPlayable=1;
 					};
-					id=1842;
+					id=2890;
 					type="potato_msv_sf_sm";
 					class CustomAttributes
 					{
@@ -31996,7 +33586,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={723.77399,5.0014391,594.82196};
+						position[]={727.95935,5.0014391,598.11493};
 					};
 					side="East";
 					flags=4;
@@ -32006,7 +33596,7 @@ class Mission
 						description="Russian Spetsnaz Automatic Rifleman";
 						isPlayable=1;
 					};
-					id=1843;
+					id=2891;
 					type="potato_msv_sf_ar";
 					class CustomAttributes
 					{
@@ -32037,7 +33627,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={719.789,5.0014391,592.80597};
+						position[]={723.97437,5.0014391,596.09894};
 					};
 					side="East";
 					flags=4;
@@ -32047,7 +33637,7 @@ class Mission
 						description="Russian Spetsnaz Assistant Automatic Rifleman";
 						isPlayable=1;
 					};
-					id=1844;
+					id=2892;
 					type="potato_msv_sf_aar";
 					class CustomAttributes
 					{
@@ -32078,7 +33668,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={723.86102,5.0014391,592.81};
+						position[]={728.04639,5.0014391,596.10297};
 					};
 					side="East";
 					flags=4;
@@ -32088,7 +33678,7 @@ class Mission
 						description="Russian Spetsnaz Assistant Grenadier";
 						isPlayable=1;
 					};
-					id=1845;
+					id=2893;
 					type="potato_msv_rifleman_04";
 					class CustomAttributes
 					{
@@ -32119,7 +33709,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={721.74902,5.0014391,592.78101};
+						position[]={725.93439,5.0014391,596.07397};
 					};
 					side="East";
 					flags=4;
@@ -32129,7 +33719,7 @@ class Mission
 						description="Russian Spetsnaz Grenadier";
 						isPlayable=1;
 					};
-					id=1899;
+					id=2894;
 					type="potato_msv_sf_g";
 					class CustomAttributes
 					{
@@ -32160,7 +33750,7 @@ class Mission
 			{
 				name="GROUP_MSV_SF";
 			};
-			id=1824;
+			id=2885;
 			class CustomAttributes
 			{
 				class Attribute0
@@ -32197,7 +33787,7 @@ class Mission
 									"STRING"
 								};
 							};
-							value="MSV SF";
+							value="MSV Spetsnaz";
 						};
 					};
 				};
@@ -32223,7 +33813,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item178
+		class Item177
 		{
 			dataType="Group";
 			side="East";
@@ -32235,7 +33825,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={720.1012,5.0014391,585.55884};
+						position[]={738.44604,5.0014391,584.77649};
 					};
 					side="East";
 					flags=6;
@@ -32243,10 +33833,10 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_MSV_JIP_SL1";
-						description="Russian JIP Squad Leader@JIP Squad";
+						description="Russian JIP Squad Leader@Russian JIP Squad";
 						isPlayable=1;
 					};
-					id=1865;
+					id=2896;
 					type="potato_msv_sl";
 				};
 				class Item1
@@ -32254,7 +33844,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={718.8222,5.0014391,584.60089};
+						position[]={737.27423,5.0014391,583.5694};
 					};
 					side="East";
 					flags=4;
@@ -32264,7 +33854,7 @@ class Mission
 						description="Russian JIP Vehicle Driver";
 						isPlayable=1;
 					};
-					id=1866;
+					id=2897;
 					type="potato_msv_vicd";
 				};
 				class Item2
@@ -32272,7 +33862,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={721.41327,5.0014391,584.07294};
+						position[]={739.8653,5.0014391,583.04144};
 					};
 					side="East";
 					flags=4;
@@ -32283,7 +33873,7 @@ class Mission
 						description="Russian JIP Vehicle Gunner";
 						isPlayable=1;
 					};
-					id=1867;
+					id=2898;
 					type="potato_msv_vicc";
 				};
 				class Item3
@@ -32291,7 +33881,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={716.41626,5.0014391,583.58575};
+						position[]={734.86829,5.0014391,582.55426};
 					};
 					side="East";
 					flags=4;
@@ -32301,7 +33891,7 @@ class Mission
 						description="Russian JIP Senior Rifleman";
 						isPlayable=1;
 					};
-					id=1868;
+					id=2899;
 					type="potato_msv_sr";
 				};
 				class Item4
@@ -32309,7 +33899,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={720.48822,5.0014391,583.44293};
+						position[]={738.94025,5.0014391,582.41144};
 					};
 					side="East";
 					flags=4;
@@ -32319,7 +33909,7 @@ class Mission
 						description="Russian JIP Vehicle Driver";
 						isPlayable=1;
 					};
-					id=1869;
+					id=2900;
 					type="potato_msv_vicd";
 				};
 				class Item5
@@ -32327,7 +33917,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={722.30835,5.0014391,582.099};
+						position[]={740.76001,5.0014391,581.0675};
 					};
 					side="East";
 					flags=4;
@@ -32335,10 +33925,10 @@ class Mission
 					{
 						rank="SERGEANT";
 						name="UNIT_MSV_JIP_SL2";
-						description="Russian JIP Squad Leader@JIP Squad";
+						description="Russian JIP Squad Leader";
 						isPlayable=1;
 					};
-					id=1870;
+					id=2901;
 					type="potato_msv_sl";
 				};
 				class Item6
@@ -32346,7 +33936,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={718.34534,5.0014391,582.70178};
+						position[]={736.79736,5.0014391,581.67029};
 					};
 					side="East";
 					flags=4;
@@ -32357,7 +33947,7 @@ class Mission
 						description="Russian JIP Vehicle Gunner";
 						isPlayable=1;
 					};
-					id=1871;
+					id=2902;
 					type="potato_msv_vicc";
 				};
 				class Item7
@@ -32365,7 +33955,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={718.78699,5.0014391,581.383};
+						position[]={737.23901,5.0014391,580.3515};
 					};
 					side="East";
 					flags=4;
@@ -32375,7 +33965,7 @@ class Mission
 						description="Russian JIP Medic";
 						isPlayable=1;
 					};
-					id=1872;
+					id=2903;
 					type="potato_msv_sm";
 					class CustomAttributes
 					{
@@ -32406,7 +33996,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={717.23236,5.0014391,581.20679};
+						position[]={735.68439,5.0014391,580.17529};
 					};
 					side="East";
 					flags=4;
@@ -32417,7 +34007,7 @@ class Mission
 						description="Russian JIP Automatic Rifleman";
 						isPlayable=1;
 					};
-					id=1873;
+					id=2904;
 					type="potato_msv_ar";
 				};
 				class Item9
@@ -32425,7 +34015,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={720.69037,5.0014391,580.39893};
+						position[]={739.1424,5.0014391,579.36743};
 					};
 					side="East";
 					flags=4;
@@ -32435,7 +34025,7 @@ class Mission
 						description="Russian JIP Rifleman";
 						isPlayable=1;
 					};
-					id=1874;
+					id=2905;
 					type="potato_msv_rifleman";
 				};
 				class Item10
@@ -32443,7 +34033,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={725.16937,5.0014391,581.36005};
+						position[]={743.6214,5.0014391,580.32855};
 					};
 					side="East";
 					flags=4;
@@ -32453,7 +34043,7 @@ class Mission
 						description="Russian JIP Grenadier";
 						isPlayable=1;
 					};
-					id=1875;
+					id=2906;
 					type="potato_msv_g";
 				};
 				class Item11
@@ -32461,7 +34051,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={715.09436,5.0014391,580.40668};
+						position[]={733.54639,5.0014391,579.37518};
 					};
 					side="East";
 					flags=4;
@@ -32471,7 +34061,7 @@ class Mission
 						description="Russian JIP Grenadier";
 						isPlayable=1;
 					};
-					id=1876;
+					id=2907;
 					type="potato_msv_g";
 				};
 				class Item12
@@ -32479,7 +34069,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={716.42847,5.0014391,579.11072};
+						position[]={734.88049,5.0014391,578.07922};
 					};
 					side="East";
 					flags=4;
@@ -32489,7 +34079,7 @@ class Mission
 						description="Russian JIP Assistant Grenadier";
 						isPlayable=1;
 					};
-					id=1877;
+					id=2908;
 					type="potato_msv_ag";
 				};
 				class Item13
@@ -32497,7 +34087,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={719.31543,5.0014391,578.31488};
+						position[]={737.76746,5.0014391,577.28339};
 					};
 					side="East";
 					flags=4;
@@ -32507,7 +34097,7 @@ class Mission
 						description="Russian JIP Senior Rifleman";
 						isPlayable=1;
 					};
-					id=1878;
+					id=2909;
 					type="potato_msv_sr";
 				};
 				class Item14
@@ -32515,7 +34105,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={721.86444,5.0014391,578.32294};
+						position[]={740.31647,5.0014391,577.29144};
 					};
 					side="East";
 					flags=4;
@@ -32526,7 +34116,7 @@ class Mission
 						description="Russian JIP Automatic Rifleman";
 						isPlayable=1;
 					};
-					id=1879;
+					id=2910;
 					type="potato_msv_ar";
 				};
 				class Item15
@@ -32534,7 +34124,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={724.1485,5.0014391,577.17004};
+						position[]={742.60052,5.0014391,576.13855};
 					};
 					side="East";
 					flags=4;
@@ -32544,7 +34134,7 @@ class Mission
 						description="Russian JIP Rifleman";
 						isPlayable=1;
 					};
-					id=1880;
+					id=2911;
 					type="potato_msv_rifleman";
 				};
 				class Item16
@@ -32552,7 +34142,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={724.05499,5.0014391,579.44897};
+						position[]={742.50702,5.0014391,578.41748};
 					};
 					side="East";
 					flags=4;
@@ -32562,7 +34152,7 @@ class Mission
 						description="Russian JIP Medic";
 						isPlayable=1;
 					};
-					id=1881;
+					id=2912;
 					type="potato_msv_sm";
 					class CustomAttributes
 					{
@@ -32593,7 +34183,7 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={726.27942,5.0014391,579.27911};
+						position[]={744.73145,5.0014391,578.24762};
 					};
 					side="East";
 					flags=4;
@@ -32603,7 +34193,7 @@ class Mission
 						description="Russian JIP Assistant Grenadier";
 						isPlayable=1;
 					};
-					id=1882;
+					id=2913;
 					type="potato_msv_ag";
 				};
 			};
@@ -32611,7 +34201,30 @@ class Mission
 			{
 				name="GROUP_MSV_JIP";
 			};
-			id=1846;
+			id=2895;
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="groupID";
+					expression="[_this, _value] call CBA_fnc_setCallsign";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="MSV JIP";
+						};
+					};
+				};
+				nAttributes=1;
+			};
 		};
 	};
 };


### PR DESCRIPTION
When merged this PR will:
- Fix some missing group slot names
- Change the group slot names to match with the unit slot names ('faction' prefix)
- Unfuck MSV Bravo's order
- Make SR/R(Mk) team green
- Add MSV 3rd platoon to make it usable at high numbers
- Group up some civs for simplicity sake