### PR TITLE
Side gear opt 3

### DIFF
--- a/CfgLoadouts.hpp
+++ b/CfgLoadouts.hpp
@@ -45,14 +45,21 @@ class CfgLoadouts {
 
   // Note: please delete any factions you're not using
   // (i.e. delete the OpFor and Civ classes in a BluFor vs Indy fight)
+
+  // West factions
+  #include "Loadouts\west_gear.hpp"
   class blu_f { // BluFor
     #include "Loadouts\us_m4_ucp.hpp"
   };
 
+  // Indy factions
+  #include "Loadouts\indy_gear.hpp"
   class ind_f { // Indy
     #include "Loadouts\ukr_ak74_ttsko.hpp"
   };
 
+  // East Factions
+  #include "Loadouts\east_gear.hpp"
   class opf_f { // OpFor
     #include "Loadouts\ru_ak74_floral.hpp"
   };
@@ -62,5 +69,6 @@ class CfgLoadouts {
   };
 
   // Civilians (mainly for RP missions)
+  #include "Loadouts\civ_gear.hpp"
   #include "Loadouts\civilians.hpp" // Bare example of doing civilian loadouts
 };

--- a/Loadouts/blankForArsenal.hpp
+++ b/Loadouts/blankForArsenal.hpp
@@ -29,10 +29,10 @@
 #define PISTOL "rhsusf_weap_m1911a1"
 #define PISTOL_MAG "rhsusf_mag_7x45acp_MHP:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_blue:2"
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_WEST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -86,8 +86,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"B_UAV_01_backpack_F"};
-  linkedItems[] += {"B_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -164,19 +164,19 @@ class Helipilot_F {// Pilot
   headgear[] = {"H_PilotHelmetHeli_B"};
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY_WEST,RADIO_LR};
+  backpackItems[] = {KEY,RADIO_LR};
   items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY_WEST,RADIO_LR};
+  backpackItems[] = {KEY,RADIO_LR};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY_WEST};
+  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {

--- a/Loadouts/brit_l85_ddpm.hpp
+++ b/Loadouts/brit_l85_ddpm.hpp
@@ -54,7 +54,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_blue:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_WEST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -111,8 +111,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"B_UAV_01_backpack_F"};
-  linkedItems[] += {"B_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -213,10 +213,10 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
-  items[] += {BASE_MEDICAL,KEY_WEST};
+  items[] += {BASE_MEDICAL,KEY};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  items[] += {RADIO_MR,KEY_WEST};
+  items[] += {RADIO_MR,KEY};
   backpackItems[] = {"Toolkit"};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };

--- a/Loadouts/brit_l85_mtp.hpp
+++ b/Loadouts/brit_l85_mtp.hpp
@@ -54,7 +54,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_blue:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_WEST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -111,8 +111,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"B_UAV_01_backpack_F"};
-  linkedItems[] += {"B_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -211,10 +211,10 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
-  items[] += {BASE_MEDICAL,KEY_WEST};
+  items[] += {BASE_MEDICAL,KEY};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  items[] += {RADIO_MR,KEY_WEST};
+  items[] += {RADIO_MR,KEY};
   backpackItems[] = {"Toolkit"};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };

--- a/Loadouts/brit_l85_wdpm.hpp
+++ b/Loadouts/brit_l85_wdpm.hpp
@@ -54,7 +54,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_blue:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_WEST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -111,8 +111,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"B_UAV_01_backpack_F"};
-  linkedItems[] += {"B_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -213,10 +213,10 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
-  items[] += {BASE_MEDICAL,KEY_WEST};
+  items[] += {BASE_MEDICAL,KEY};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  items[] += {RADIO_MR,KEY_WEST};
+  items[] += {RADIO_MR,KEY};
   backpackItems[] = {"Toolkit"};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };

--- a/Loadouts/chi_qbz95_universal.hpp
+++ b/Loadouts/chi_qbz95_universal.hpp
@@ -53,7 +53,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_red:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_EAST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -107,8 +107,8 @@ class officer_F: Soldier_SL_F { // CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"O_UAV_01_backpack_F"};
-  linkedItems[] += {"O_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class soldier_GL_F: Soldier_TL_F {}; // GP Dude
 class Soldier_AR_F: Soldier_F {// AR
@@ -193,12 +193,12 @@ class Helipilot_F {// Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   backpack[] = {"MNP_B_Carryall_PLA_Basic"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {KEY_EAST,RADIO_LR};
+  backpackItems[] += {KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY_EAST};
+  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {

--- a/Loadouts/civ_gear.hpp
+++ b/Loadouts/civ_gear.hpp
@@ -1,0 +1,6 @@
+#include "undef_side_gear.hpp"  // Reset defines
+
+#define KEY "ACE_key_civ"
+#define CHEM_LIGHT "Chemlight_yellow"
+#define UAV_BACKPACK "C_IDAP_UAV_01_backpack_F" // Orange DLC notice
+#define UAV_TERMINAL "C_uavterminal" // test, not on wiki

--- a/Loadouts/common.hpp
+++ b/Loadouts/common.hpp
@@ -5,11 +5,6 @@
 #define RADIO_MR "ACRE_PRC148"
 #define RADIO_LR "ACRE_PRC117F"
 
-// KEYS
-#define KEY_WEST "ACE_key_west"
-#define KEY_EAST "ACE_key_east"
-#define KEY_IND "ACE_key_indp"
-
 // GEAR
 #define BASE_MEDICAL "ACE_elasticBandage:4","ACE_packingBandage:2","ACE_tourniquet","ACE_morphine"
 #define MEDIC_MEDICAL "ACE_elasticBandage:25","ACE_packingBandage:15","ACE_epinephrine:10","ACE_salineIV:2","ACE_salineIV_500:4","ACE_salineIV_250:8","ACE_morphine:16","ACE_tourniquet:6"

--- a/Loadouts/csat_qbz95_pacmech_apex.hpp
+++ b/Loadouts/csat_qbz95_pacmech_apex.hpp
@@ -51,7 +51,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_red:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_EAST,"H_HelmetLeaderO_ghex_F"
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY,"H_HelmetLeaderO_ghex_F"
 #define BASE_LINKED COMMON_LINKED,"O_NVGoggles_ghex_F"
 #define MSV_EXP "DemoCharge_Remote_Mag:2"
 
@@ -90,7 +90,7 @@ class potato_msv_sr: potato_msv_rifleman {// FTL
   vest[] = {"V_HarnessOGL_ghex_F"};
   weapons[] = {GLRIFLE};
   magazines[] = {GLRIFLE_MAG,GLRIFLE_MAG_HE,GLRIFLE_MAG_SMOKE,LEADER_GRENADES};
-  items[] += {COMMON_LEADER_TOOLS,KEY_EAST};
+  items[] += {COMMON_LEADER_TOOLS,KEY};
   linkedItems[] += {LEADER_LINKED,BINOS};
 };
 class potato_msv_sl: potato_msv_sr { // SL
@@ -205,7 +205,7 @@ class potato_msv_cc: potato_msv_pilot {// Crew Chief
 class fic_vehicle_crewman: potato_msv_rifleman {// Vehicle crew base
   headgear[] = {"H_HelmetCrew_O_ghex_F"};
   magazines[] = {RIFLE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY_EAST};
+  backpackItems[] = {KEY};
   linkedItems[] += {BASE_LINKED,LEADER_LINKED};
   items[] += {BASE_MEDICAL};
 };
@@ -227,7 +227,7 @@ class potato_msv_eng: potato_msv_rifleman {// Demoman
   linkedItems[] = {BASE_LINKED};
 };
 class potato_msv_engl: potato_msv_eng {// Demoman Leader
-  backpackItems[] += {RADIO_MR,KEY_EAST};
+  backpackItems[] += {RADIO_MR,KEY};
   linkedItems[] += {LEADER_LINKED};
 };
 class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman
@@ -244,7 +244,7 @@ class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman
   opticChoices[] = {};
 };
 class potato_msv_sf_ftl: potato_msv_sf_rifleman {// Recon Senior Rifleman
-  items[] += {COMMON_LEADER_TOOLS,KEY_EAST}; // Avoid using leader linked because it adds double headgear (viper is not mechanized)
+  items[] += {COMMON_LEADER_TOOLS,KEY}; // Avoid using leader linked because it adds double headgear (viper is not mechanized)
   linkedItems[] += {COMMON_LEADER_TOOLS,BINOS};
 };
 class potato_msv_sf_sl: potato_msv_sf_ftl {// Recon Squad Leader

--- a/Loadouts/east_gear.hpp
+++ b/Loadouts/east_gear.hpp
@@ -1,0 +1,6 @@
+#include "undef_side_gear.hpp"  // Reset defines
+
+#define KEY "ACE_key_east"
+#define CHEM_LIGHT "Chemlight_red"
+#define UAV_BACKPACK "O_UAV_01_backpack_F"
+#define UAV_TERMINAL "O_uavterminal"

--- a/Loadouts/ger_g38_fleck.hpp
+++ b/Loadouts/ger_g38_fleck.hpp
@@ -53,7 +53,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_blue:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_WEST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -107,8 +107,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"B_UAV_01_backpack_F"};
-  linkedItems[] += {"B_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -191,12 +191,12 @@ class Helipilot_F {// Pilot
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY_WEST,RADIO_LR};
+  backpackItems[] = {KEY,RADIO_LR};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY_WEST};
+  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {

--- a/Loadouts/ger_g38_tropen.hpp
+++ b/Loadouts/ger_g38_tropen.hpp
@@ -53,7 +53,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_blue:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_WEST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -107,8 +107,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"B_UAV_01_backpack_F"};
-  linkedItems[] += {"B_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -191,12 +191,12 @@ class Helipilot_F {// Pilot
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY_WEST,RADIO_LR};
+  backpackItems[] = {KEY,RADIO_LR};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY_WEST};
+  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {

--- a/Loadouts/indy_gear.hpp
+++ b/Loadouts/indy_gear.hpp
@@ -1,0 +1,6 @@
+#include "undef_side_gear.hpp"  // Reset defines
+
+#define KEY "ACE_key_indp"
+#define CHEM_LIGHT "Chemlight_green"
+#define UAV_BACKPACK "I_UAV_01_backpack_F"
+#define UAV_TERMINAL "I_uavterminal"

--- a/Loadouts/msv_ak74_emr.hpp
+++ b/Loadouts/msv_ak74_emr.hpp
@@ -50,7 +50,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_red:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_EAST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED,"rhs_1PN138" // To be moved to tools if loadout bug is fixed
 #define LEADER_LINKED COMMON_LEADER_LINKED
 #define MSV_EXP "DemoCharge_Remote_Mag:2"
@@ -206,7 +206,7 @@ class potato_msv_cc: potato_msv_pilot {};// Crew Chief
 class fic_vehicle_crewman: potato_msv_rifleman {// Vehicle crew base
   headgear[] = {"rhs_tsh4","rhs_tsh4_bala","rhs_tsh4_ess","rhs_tsh4_ess_bala"};
   magazines[] = {RIFLE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY_EAST};
+  backpackItems[] = {KEY};
   linkedItems[] += {BASE_LINKED,LEADER_LINKED};
   items[] += {BASE_MEDICAL};
 };
@@ -227,7 +227,7 @@ class potato_msv_eng: potato_msv_rifleman {// Demoman
   magazines[] += {MSV_EXP};
 };
 class potato_msv_engl: potato_msv_eng {// Demoman Leader
-  backpackItems[] += {RADIO_MR,KEY_EAST};
+  backpackItems[] += {RADIO_MR,KEY};
   linkedItems[] += {LEADER_LINKED};
 };
 class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman

--- a/Loadouts/msv_ak74_emrd.hpp
+++ b/Loadouts/msv_ak74_emrd.hpp
@@ -58,7 +58,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_red:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_EAST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED,"rhs_1PN138" // To be moved to tools if loadout bug is fixed
 #define LEADER_LINKED COMMON_LEADER_LINKED
 #define MSV_EXP "DemoCharge_Remote_Mag:2"
@@ -214,7 +214,7 @@ class potato_msv_cc: potato_msv_pilot {};// Crew Chief
 class fic_vehicle_crewman: potato_msv_rifleman {// Vehicle crew base
   headgear[] = {"rhs_tsh4","rhs_tsh4_bala","rhs_tsh4_ess","rhs_tsh4_ess_bala"};
   magazines[] = {RIFLE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY_EAST};
+  backpackItems[] = {KEY};
   linkedItems[] += {BASE_LINKED,LEADER_LINKED};
   items[] += {BASE_MEDICAL};
 };
@@ -235,7 +235,7 @@ class potato_msv_eng: potato_msv_rifleman {// Demoman
   magazines[] += {MSV_EXP};
 };
 class potato_msv_engl: potato_msv_eng {// Demoman Leader
-  backpackItems[] += {RADIO_MR,KEY_EAST};
+  backpackItems[] += {RADIO_MR,KEY};
   linkedItems[] += {LEADER_LINKED};
 };
 class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman

--- a/Loadouts/msv_ak74_flora.hpp
+++ b/Loadouts/msv_ak74_flora.hpp
@@ -50,7 +50,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_red:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_EAST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED,"rhs_1PN138" // To be moved to tools if loadout bug is fixed
 #define LEADER_LINKED COMMON_LEADER_LINKED
 #define MSV_EXP "DemoCharge_Remote_Mag:2"
@@ -206,7 +206,7 @@ class potato_msv_cc: potato_msv_pilot {};// Crew Chief
 class fic_vehicle_crewman: potato_msv_rifleman {// Vehicle crew base
   headgear[] = {"rhs_tsh4","rhs_tsh4_bala","rhs_tsh4_ess","rhs_tsh4_ess_bala"};
   magazines[] = {RIFLE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY_EAST};
+  backpackItems[] = {KEY};
   linkedItems[] += {BASE_LINKED,LEADER_LINKED};
   items[] += {BASE_MEDICAL};
 };
@@ -227,7 +227,7 @@ class potato_msv_eng: potato_msv_rifleman {// Demoman
   magazines[] += {MSV_EXP};
 };
 class potato_msv_engl: potato_msv_eng {// Demoman Leader
-  backpackItems[] += {RADIO_MR,KEY_EAST};
+  backpackItems[] += {RADIO_MR,KEY};
   linkedItems[] += {LEADER_LINKED};
 };
 class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman

--- a/Loadouts/msv_akm_soviet.hpp
+++ b/Loadouts/msv_akm_soviet.hpp
@@ -52,7 +52,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_red:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_EAST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED,"rhs_1PN138" // To be moved to tools if loadout bug is fixed
 #define LEADER_LINKED COMMON_LEADER_LINKED
 #define MSV_EXP "DemoCharge_Remote_Mag:2"
@@ -206,7 +206,7 @@ class potato_msv_cc: potato_msv_pilot {};// Crew Chief
 class fic_vehicle_crewman: potato_msv_rifleman {// Vehicle crew base
   headgear[] = {"rhs_tsh4","rhs_tsh4_bala","rhs_tsh4_ess","rhs_tsh4_ess_bala"};
   magazines[] = {RIFLE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY_EAST};
+  backpackItems[] = {KEY};
   linkedItems[] += {BASE_LINKED,LEADER_LINKED};
   items[] += {BASE_MEDICAL};
 };
@@ -227,7 +227,7 @@ class potato_msv_eng: potato_msv_rifleman {// Demoman
   magazines[] += {MSV_EXP};
 };
 class potato_msv_engl: potato_msv_eng {// Demoman Leader
-  backpackItems[] += {RADIO_MR,KEY_EAST};
+  backpackItems[] += {RADIO_MR,KEY};
   linkedItems[] += {LEADER_LINKED};
 };
 class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman

--- a/Loadouts/reb_ak47_desert.hpp
+++ b/Loadouts/reb_ak47_desert.hpp
@@ -52,7 +52,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_green:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_IND
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -108,8 +108,8 @@ class officer_F: Soldier_SL_F {// CO and DC
 };
 class soldier_UAV_F: Soldier_F {
   vest[] = {"MNP_Vest_UKR_B","MNP_Vest_6co_A","MNP_Vest_6co_B"};
-  backpack[] = {"I_UAV_01_backpack_F"};
-  linkedItems[] += {"I_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -206,13 +206,13 @@ class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"MNP_Vest_UKR_B","MNP_Vest_6co_A","MNP_Vest_6co_B"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY_IND,RADIO_LR};
+  backpackItems[] = {KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class Soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_khk"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY_IND};
+  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };
 class Fic_Eng: soldier_repair_F {

--- a/Loadouts/ru_ak74_desert.hpp
+++ b/Loadouts/ru_ak74_desert.hpp
@@ -54,7 +54,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_red:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_EAST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -109,8 +109,8 @@ class officer_F: Soldier_SL_F { // CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"O_UAV_01_backpack_F"};
-  linkedItems[] += {"O_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class soldier_GL_F: Soldier_TL_F {}; // GP Dude
 class Soldier_AR_F: Soldier_F {// AR
@@ -203,12 +203,12 @@ class Helipilot_F {// Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   backpack[] = {"rhs_assault_umbts_engineer_empty"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {KEY_EAST,RADIO_LR};
+  backpackItems[] += {KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY_EAST};
+  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {

--- a/Loadouts/ru_ak74_floral.hpp
+++ b/Loadouts/ru_ak74_floral.hpp
@@ -54,7 +54,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_red:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_EAST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -110,8 +110,8 @@ class officer_F: Soldier_SL_F { // CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"O_UAV_01_backpack_F"};
-  linkedItems[] += {"O_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class soldier_GL_F: Soldier_TL_F {}; // GP Dude
 class Soldier_AR_F: Soldier_F {// AR
@@ -202,12 +202,12 @@ class Helipilot_F {// Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   backpack[] = {"rhs_assault_umbts_engineer_empty"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {KEY_EAST,RADIO_LR};
+  backpackItems[] += {KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY_EAST};
+  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {

--- a/Loadouts/ukr_ak74_ddpm.hpp
+++ b/Loadouts/ukr_ak74_ddpm.hpp
@@ -52,7 +52,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_green:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_IND
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -106,8 +106,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"I_UAV_01_backpack_F"};
-  linkedItems[] += {"I_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -195,13 +195,13 @@ class Helipilot_F {// Pilot
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {KEY_IND,RADIO_LR};
+  backpackItems[] += {KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class Soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_khk"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY_IND};
+  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };
 class Fic_Eng: soldier_repair_F {

--- a/Loadouts/ukr_ak74_ttsko.hpp
+++ b/Loadouts/ukr_ak74_ttsko.hpp
@@ -52,7 +52,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_green:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_IND
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -106,8 +106,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"I_UAV_01_backpack_F"};
-  linkedItems[] += {"I_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -196,13 +196,13 @@ class Helipilot_F {// Pilot
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {KEY_IND,RADIO_LR};
+  backpackItems[] += {KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class Soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"MNP_B_WD_CA"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY_IND};
+  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };
 class Fic_Eng: soldier_repair_F {

--- a/Loadouts/undef_side_gear.hpp
+++ b/Loadouts/undef_side_gear.hpp
@@ -1,0 +1,13 @@
+// Reset side defines
+#ifdef KEY
+  #undef KEY
+#endif
+#ifdef CHEM_LIGHT
+  #undef CHEM_LIGHT
+#endif
+#ifdef UAV_BACKPACK
+  #undef UAV_BACKPACK
+#endif
+#ifdef UAV_TERMINAL
+  #undef UAV_TERMINAL
+#endif

--- a/Loadouts/us_m4_ocp.hpp
+++ b/Loadouts/us_m4_ocp.hpp
@@ -53,7 +53,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_blue:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_WEST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -110,8 +110,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"B_UAV_01_backpack_F"};
-  linkedItems[] += {"B_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   vest[] = {"rhsusf_iotv_ocp_SAW"};
@@ -204,13 +204,13 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   headgear[] = {"rhsusf_cvc_green_ess"};
   backpack[] = {"B_Carryall_mcamo"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY_WEST,RADIO_LR};
+  backpackItems[] = {KEY,RADIO_LR};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_mcamo"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY_WEST};
+  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
   vest[] = {"rhsusf_iotv_ocp_repair"};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };

--- a/Loadouts/us_m4_ucp.hpp
+++ b/Loadouts/us_m4_ucp.hpp
@@ -53,7 +53,7 @@
 #define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,"Chemlight_blue:2"
 // Gear
 #define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY_WEST
+#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
 #define BASE_LINKED COMMON_LINKED
 #define LEADER_LINKED COMMON_LEADER_LINKED
 
@@ -110,8 +110,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {"B_UAV_01_backpack_F"};
-  linkedItems[] += {"B_uavterminal"};
+  backpack[] = {UAV_BACKPACK};
+  linkedItems[] += {UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   vest[] = {"rhsusf_iotv_ucp_SAW"};
@@ -204,13 +204,13 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   headgear[] = {"rhsusf_cvc_green_ess"};
   backpack[] = {"B_Carryall_mcamo"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY_WEST,RADIO_LR};
+  backpackItems[] = {KEY,RADIO_LR};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_mcamo"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY_WEST};
+  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
   vest[] = {"rhsusf_iotv_ucp_repair"};
   linkedItems[] = {BASE_LINKED,LEADER_LINKED};
 };

--- a/Loadouts/west_gear.hpp
+++ b/Loadouts/west_gear.hpp
@@ -1,0 +1,6 @@
+#include "undef_side_gear.hpp" // Reset defines
+
+#define KEY "ACE_key_west"
+#define CHEM_LIGHT "Chemlight_blue"
+#define UAV_BACKPACK "B_UAV_01_backpack_F"
+#define UAV_TERMINAL "B_uavterminal"


### PR DESCRIPTION
Side specific gear done through a set of side gear loadout files

Pros:
- Allows all kinds of gear to be defined is a side (could do faction if needed) specific fashion
- Not tied to specific prefix/item formats
- No special macros need to be used in the loadouts
- Very little cfg loadout file clutter

Cons:
- Adds 4 new loadout file, and one undef file (undef is really only needed for strict linters)
- Items aren't exactly tied to each other side to side, so possible to be missing defines