### PR TITLE
Commonize alt optics

### DIFF
--- a/CfgLoadouts.hpp
+++ b/CfgLoadouts.hpp
@@ -49,7 +49,7 @@ class CfgLoadouts {
   // West factions
   #include "Loadouts\west_gear.hpp"
   class blu_f { // BluFor
-    #include "Loadouts\us_m4_ucp.hpp"
+    #include "Loadouts\us_m4_ocp.hpp"
   };
 
   // Indy factions

--- a/Loadouts/brit_l85_ddpm.hpp
+++ b/Loadouts/brit_l85_ddpm.hpp
@@ -6,9 +6,9 @@
 // Rifle
 #define RIFLE "CUP_arifle_L85A2_G","CUP_arifle_L85A2_NG"
 #define RIFLE_MAG "30Rnd_556x45_Stanag_red:8","30Rnd_556x45_Stanag_Tracer_Red:2"
-#define RIFLE_ATTACHMENTS "CUP_optic_HoloBlack","CUP_acc_ANPEQ_2"
+#define RIFLE_ATTACHMENTS "CUP_acc_ANPEQ_2"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define ALT_OPTICS "optic_Aco","rhsusf_acc_compm4","rhsusf_acc_eotech_xps3","CUP_optic_CompM2_Black","CUP_optic_TrijiconRx01_black","CUP_optic_MRad"
+#define ALT_OPTICS STANAG_OPTICS
 // GL Rifle
 #define GLRIFLE "CUP_arifle_L85A2_GL"
 #define GLRIFLE_MAG RIFLE_MAG

--- a/Loadouts/brit_l85_mtp.hpp
+++ b/Loadouts/brit_l85_mtp.hpp
@@ -6,9 +6,9 @@
 // Rifle
 #define RIFLE "CUP_arifle_L85A2_G","CUP_arifle_L85A2_NG"
 #define RIFLE_MAG "30Rnd_556x45_Stanag_red:8","30Rnd_556x45_Stanag_Tracer_Red:2"
-#define RIFLE_ATTACHMENTS "CUP_optic_HoloBlack","CUP_acc_ANPEQ_2"
+#define RIFLE_ATTACHMENTS "CUP_acc_ANPEQ_2"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define ALT_OPTICS "optic_Aco","rhsusf_acc_compm4","rhsusf_acc_eotech_xps3","CUP_optic_CompM2_Black","CUP_optic_TrijiconRx01_black","CUP_optic_MRad"
+#define ALT_OPTICS STANAG_OPTICS
 // GL Rifle
 #define GLRIFLE "CUP_arifle_L85A2_GL"
 #define GLRIFLE_MAG RIFLE_MAG

--- a/Loadouts/brit_l85_wdpm.hpp
+++ b/Loadouts/brit_l85_wdpm.hpp
@@ -6,9 +6,9 @@
 // Rifle
 #define RIFLE "CUP_arifle_L85A2_G","CUP_arifle_L85A2_NG"
 #define RIFLE_MAG "30Rnd_556x45_Stanag_red:8","30Rnd_556x45_Stanag_Tracer_Red:2"
-#define RIFLE_ATTACHMENTS "CUP_optic_HoloBlack","CUP_acc_ANPEQ_2"
+#define RIFLE_ATTACHMENTS "CUP_acc_ANPEQ_2"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define ALT_OPTICS "optic_Aco","rhsusf_acc_compm4","rhsusf_acc_eotech_xps3","CUP_optic_CompM2_Black","CUP_optic_TrijiconRx01_black","CUP_optic_MRad"
+#define ALT_OPTICS STANAG_OPTICS
 // GL Rifle
 #define GLRIFLE "CUP_arifle_L85A2_GL"
 #define GLRIFLE_MAG RIFLE_MAG

--- a/Loadouts/chi_qbz95_universal.hpp
+++ b/Loadouts/chi_qbz95_universal.hpp
@@ -6,9 +6,9 @@
 // Rifle
 #define RIFLE "arifle_CTAR_blk_F"
 #define RIFLE_MAG "30Rnd_580x42_Mag_F:8","30Rnd_580x42_Mag_Tracer_F:2"
-#define RIFLE_ATTACHMENTS "optic_ACO_grn","acc_pointer_IR"
+#define RIFLE_ATTACHMENTS "acc_pointer_IR"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define ALT_OPTICS "rhsusf_acc_compm4","rhsusf_acc_eotech_xps3","CUP_optic_CompM2_Black","CUP_optic_TrijiconRx01_black","CUP_optic_MRad"
+#define ALT_OPTICS STANAG_OPTICS
 // GL Rifle
 #define GLRIFLE "arifle_CTAR_GL_blk_F"
 #define GLRIFLE_MAG RIFLE_MAG

--- a/Loadouts/common.hpp
+++ b/Loadouts/common.hpp
@@ -24,6 +24,10 @@
 #define BINOS "Binocular"
 #define RANGE_FINDER "ACE_Vector"
 
+// OPTIX
+#define WARSAW_OPTICS "rhs_acc_1p63", "rhs_acc_ekp1", "rhs_acc_ekp8_02", "rhs_acc_pkas" // note RHS and CUP mount optics differently, not cross compatible
+#define STANAG_OPTICS "optic_Aco", "optic_Yorris", "rhs_acc_1p87", "rhs_acc_ekp8_18", "rhs_acc_rakursPM", "rhsusf_acc_compm4", "rhsusf_acc_eotech_xps3", "rhsusf_acc_T1_high", "CUP_optic_MRad", "CUP_optic_ZDDot"
+
 // FUNCTIONS
 #define SAM_GEAR(BACKPACK,MAG) backpack[] = {BACKPACK}; backpackItems[] = {}; magazines[] += {MAG}; items[] += {BASE_MEDICAL};
 #define MORTAR_GEAR(BACKPACK) backpack[] = {BACKPACK}; items[] += {"ACE_RangeTable_82mm"};

--- a/Loadouts/csat_qbz95_pacmech_apex.hpp
+++ b/Loadouts/csat_qbz95_pacmech_apex.hpp
@@ -7,9 +7,9 @@
 // Rifle
 #define RIFLE "arifle_CTAR_ghex_F"
 #define RIFLE_MAG "30Rnd_580x42_Mag_F:8","30Rnd_580x42_Mag_Tracer_F:2"
-#define RIFLE_ATTACHMENTS "optic_ACO_grn","acc_pointer_IR"
+#define RIFLE_ATTACHMENTS "acc_pointer_IR"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define ALT_OPTICS "optic_Arco_ghex_F","optic_Holosight_blk_F"
+#define ALT_OPTICS STANAG_OPTICS
 // GL Rifle
 #define GLRIFLE "arifle_CTAR_GL_ghex_F"
 #define GLRIFLE_MAG RIFLE_MAG

--- a/Loadouts/ger_g38_fleck.hpp
+++ b/Loadouts/ger_g38_fleck.hpp
@@ -6,9 +6,9 @@
 // Rifle
 #define RIFLE "rhs_weap_hk416d145"
 #define RIFLE_MAG "30Rnd_556x45_Stanag_red:8","30Rnd_556x45_Stanag_Tracer_Red:2"
-#define RIFLE_ATTACHMENTS "rhsusf_acc_eotech_xps3","rhsusf_acc_anpeq15side_bk"
+#define RIFLE_ATTACHMENTS "rhsusf_acc_anpeq15side_bk"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define ALT_OPTICS "optic_Aco","rhsusf_acc_compm4","CUP_optic_HoloBlack","CUP_optic_CompM2_Black","CUP_optic_TrijiconRx01_black","CUP_optic_MRad"
+#define ALT_OPTICS STANAG_OPTICS
 // GL Rifle
 #define GLRIFLE "rhs_weap_hk416d145_m320"
 #define GLRIFLE_MAG RIFLE_MAG

--- a/Loadouts/ger_g38_tropen.hpp
+++ b/Loadouts/ger_g38_tropen.hpp
@@ -6,9 +6,9 @@
 // Rifle
 #define RIFLE "rhs_weap_hk416d145"
 #define RIFLE_MAG "30Rnd_556x45_Stanag_red:8","30Rnd_556x45_Stanag_Tracer_Red:2"
-#define RIFLE_ATTACHMENTS "rhsusf_acc_eotech_xps3","rhsusf_acc_anpeq15side_bk"
+#define RIFLE_ATTACHMENTS "rhsusf_acc_anpeq15side_bk"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define ALT_OPTICS "optic_Aco","rhsusf_acc_compm4","CUP_optic_HoloBlack","CUP_optic_CompM2_Black","CUP_optic_TrijiconRx01_black","CUP_optic_MRad"
+#define ALT_OPTICS STANAG_OPTICS
 // GL Rifle
 #define GLRIFLE "rhs_weap_hk416d145_m320"
 #define GLRIFLE_MAG RIFLE_MAG

--- a/Loadouts/msv_ak74_emr.hpp
+++ b/Loadouts/msv_ak74_emr.hpp
@@ -6,9 +6,9 @@
 // Rifle
 #define RIFLE "rhs_weap_ak74m_camo","rhs_weap_ak74m_2mag_camo","rhs_weap_ak74m","rhs_weap_ak74m_2mag"
 #define RIFLE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
-#define RIFLE_ATTACHMENTS "rhs_acc_pkas","rhs_acc_dtk","rhs_acc_perst1ik"
+#define RIFLE_ATTACHMENTS "rhs_acc_dtk","rhs_acc_perst1ik"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define ALT_OPTICS "rhs_acc_1p29","rhs_acc_1p63","rhs_acc_1p78","rhs_acc_1pn93_1","rhs_acc_ekp1"
+#define ALT_OPTICS WARSAW_OPTICS,"rhs_acc_1p29","rhs_acc_1p78","rhs_acc_1pn93_1"
 // GL Rifle
 #define GLRIFLE "rhs_weap_ak74m_gp25"
 #define GLRIFLE_MAG RIFLE_MAG
@@ -18,6 +18,7 @@
 // AR
 #define AR "CUP_arifle_RPK74M"
 #define AR_MAG "CUP_75Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M:6"
+#define AR_ATTACHMENTS "CUP_optic_Kobra"
 // Recon Rifle Attachments
 #define RECON_RIFLE_ATTACHMENTS "rhs_acc_tgpa","rhs_acc_2dpZenit","rhs_acc_pkas"
 // AT
@@ -122,7 +123,7 @@ class potato_msv_AR: potato_msv_rifleman {// AR
   weapons[] = {AR};
   magazines[] = {AR_MAG,PISTOL_MAG,BASE_GRENADES};
   handguns[] = {PISTOL};
-  attachments[] = {"CUP_optic_Kobra"};
+  attachments[] = {AR_ATTACHMENTS};
   opticChoices[] = {};
 };
 class potato_msv_g: potato_msv_rifleman {// Grenadier

--- a/Loadouts/msv_ak74_emrd.hpp
+++ b/Loadouts/msv_ak74_emrd.hpp
@@ -6,9 +6,9 @@
 // Rifle
 #define RIFLE "rhs_weap_ak74m_camo","rhs_weap_ak74m_2mag_camo","rhs_weap_ak74m","rhs_weap_ak74m_2mag","rhs_weap_ak74m_desert"
 #define RIFLE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
-#define RIFLE_ATTACHMENTS "rhs_acc_pkas","rhs_acc_dtk","rhs_acc_perst1ik"
+#define RIFLE_ATTACHMENTS "rhs_acc_dtk","rhs_acc_perst1ik"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define ALT_OPTICS "rhs_acc_1p29","rhs_acc_1p63","rhs_acc_1p78","rhs_acc_1pn93_1","rhs_acc_ekp1"
+#define ALT_OPTICS WARSAW_OPTICS,"rhs_acc_1p29","rhs_acc_1p78","rhs_acc_1pn93_1"
 // GL Rifle
 #define GLRIFLE "rhs_weap_ak74m_gp25"
 #define GLRIFLE_MAG RIFLE_MAG
@@ -18,6 +18,7 @@
 // AR
 #define AR "CUP_arifle_RPK74M"
 #define AR_MAG "CUP_75Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M:6"
+#define AR_ATTACHMENTS "CUP_optic_Kobra"
 // Recon Rifle Attachments
 #define RECON_RIFLE_ATTACHMENTS "rhs_acc_tgpa","rhs_acc_2dpZenit","rhs_acc_pkas"
 // AT
@@ -130,7 +131,7 @@ class potato_msv_AR: potato_msv_rifleman {// AR
   weapons[] = {AR};
   magazines[] = {AR_MAG,PISTOL_MAG,BASE_GRENADES};
   handguns[] = {PISTOL};
-  attachments[] = {"CUP_optic_Kobra"};
+  attachments[] = {AR_ATTACHMENTS};
   opticChoices[] = {};
 };
 class potato_msv_g: potato_msv_rifleman {// Grenadier

--- a/Loadouts/msv_ak74_flora.hpp
+++ b/Loadouts/msv_ak74_flora.hpp
@@ -6,9 +6,9 @@
 // Rifle
 #define RIFLE "rhs_weap_ak74m_camo","rhs_weap_ak74m_2mag_camo","rhs_weap_ak74m","rhs_weap_ak74m_2mag"
 #define RIFLE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
-#define RIFLE_ATTACHMENTS "rhs_acc_pkas","rhs_acc_dtk","rhs_acc_perst1ik"
+#define RIFLE_ATTACHMENTS "rhs_acc_dtk","rhs_acc_perst1ik"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define ALT_OPTICS "rhs_acc_1p29","rhs_acc_1p63","rhs_acc_1p78","rhs_acc_1pn93_1","rhs_acc_ekp1"
+#define ALT_OPTICS WARSAW_OPTICS,"rhs_acc_1p29","rhs_acc_1p78","rhs_acc_1pn93_1"
 // GL Rifle
 #define GLRIFLE "rhs_weap_ak74m_gp25"
 #define GLRIFLE_MAG RIFLE_MAG
@@ -18,6 +18,7 @@
 // AR
 #define AR "CUP_arifle_RPK74M"
 #define AR_MAG "CUP_75Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M:6"
+#define AR_ATTACHMENTS "CUP_optic_Kobra"
 // Recon Rifle Attachments
 #define RECON_RIFLE_ATTACHMENTS "rhs_acc_tgpa","rhs_acc_2dpZenit","rhs_acc_pkas"
 // AT
@@ -122,7 +123,7 @@ class potato_msv_AR: potato_msv_rifleman {// AR
   weapons[] = {AR};
   magazines[] = {AR_MAG,PISTOL_MAG,BASE_GRENADES};
   handguns[] = {PISTOL};
-  attachments[] = {};
+  attachments[] = {AR_ATTACHMENTS};
   opticChoices[] = {};
 };
 class potato_msv_g: potato_msv_rifleman {// Grenadier

--- a/Loadouts/msv_akm_soviet.hpp
+++ b/Loadouts/msv_akm_soviet.hpp
@@ -4,22 +4,24 @@
 #include "undef.hpp" // Reset defines
 
 // Rifle
-#define RIFLE "rhs_weap_akm"
+#define RIFLE "rhs_weap_akmn"
 #define RIFLE_MAG "30Rnd_762x39_Mag_F:8","30Rnd_762x39_Mag_Tracer_Green_F:2"
-#define RIFLE_ATTACHMENTS "rhs_acc_dtk1l"
+#define RIFLE_ATTACHMENTS "rhs_acc_dtkakm","rhs_acc_perst1ik"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
+#define ALT_OPTICS WARSAW_OPTICS,"rhs_acc_1p29","rhs_acc_1p78","rhs_acc_1pn93_1"
 // GL Rifle
-#define GLRIFLE "rhs_weap_akm_gp25","rhs_weap_akms_gp25"
+#define GLRIFLE "rhs_weap_akmn_gp25"
 #define GLRIFLE_MAG RIFLE_MAG
 #define GLRIFLE_MAG_SMOKE "rhs_GRD40_White:2","rhs_GRD40_Red:2"
 #define GLRIFLE_MAG_HE "rhs_VOG25:5"
 #define GLRIFLE_MAG_FLARE "rhs_VG40OP_red:4"
 // Carbine
-#define CARBINE "rhs_weap_akms"
+#define CARBINE RIFLE
 #define CARBINE_MAG RIFLE_MAG
 // AR
 #define AR "potato_arifle_RPK"
 #define AR_MAG "potato_75Rnd_762x39mm_tracer:6"
+#define AR_ATTACHMENTS "CUP_optic_Kobra"
 // Recon Rifle Attachments
 #define RECON_RIFLE_ATTACHMENTS "rhs_acc_pbs1"
 // AT
@@ -123,7 +125,8 @@ class potato_msv_AR: potato_msv_rifleman {// AR
   weapons[] = {AR};
   magazines[] = {AR_MAG,PISTOL_MAG,BASE_GRENADES};
   handguns[] = {PISTOL};
-  attachments[] = {};
+  attachments[] = {AR_ATTACHMENTS};
+  opticChoices[] = {};
 };
 class potato_msv_g: potato_msv_rifleman {// Grenadier
   magazines[] += {AT_MAG};

--- a/Loadouts/reb_ak47_desert.hpp
+++ b/Loadouts/reb_ak47_desert.hpp
@@ -142,8 +142,6 @@ class support_MG_F: Soldier_AR_F {// MMG
   backpack[] = {"B_Kitbag_rgr"};
   weapons[] = {MMG};
   magazines[] = {MMG_MAG,PISTOL_MAG,BASE_GRENADES};
-  attachments[] = {};
-  opticChoices[] = {};
 };
 class Soldier_A_F: Fic_Spotter {// MMG Spotter/Ammo Bearer
   backpack[] = {"B_Kitbag_rgr"};

--- a/Loadouts/reb_ak47_desert.hpp
+++ b/Loadouts/reb_ak47_desert.hpp
@@ -19,6 +19,7 @@
 // AR
 #define AR "potato_arifle_RPK"
 #define AR_MAG "potato_75Rnd_762x39mm_tracer:5"
+#define AR_ATTACHMENTS "CUP_optic_Kobra"
 // AT
 #define AT "rhs_weap_rpg7"
 #define AT_MAG "rhs_rpg7_PG7VL_mag:1"
@@ -115,7 +116,8 @@ class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
   magazines[] = {AR_MAG,PISTOL_MAG,BASE_GRENADES};
   handguns[] = {PISTOL};
-  attachments[] = {};
+  attachments[] = {AR_ATTACHMENTS};
+  opticChoices[] = {};
 };
 class Soldier_AAR_F: Soldier_F {// AAR
   backpackItems[] += {AR_MAG};
@@ -140,6 +142,8 @@ class support_MG_F: Soldier_AR_F {// MMG
   backpack[] = {"B_Kitbag_rgr"};
   weapons[] = {MMG};
   magazines[] = {MMG_MAG,PISTOL_MAG,BASE_GRENADES};
+  attachments[] = {};
+  opticChoices[] = {};
 };
 class Soldier_A_F: Fic_Spotter {// MMG Spotter/Ammo Bearer
   backpack[] = {"B_Kitbag_rgr"};

--- a/Loadouts/ru_ak74_desert.hpp
+++ b/Loadouts/ru_ak74_desert.hpp
@@ -4,12 +4,11 @@
 #include "undef.hpp" // Reset defines
 
 // Rifle
-#define RIFLE "rhs_weap_ak74m_camo","rhs_weap_ak74m_2mag_camo","rhs_weap_ak74m","rhs_weap_ak74m_2mag"
+#define RIFLE "rhs_weap_ak74m","rhs_weap_ak74m_2mag","rhs_weap_ak74m_desert"
 #define RIFLE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
-#define RIFLE_ATTACHMENTS "rhs_acc_1p63","rhs_acc_dtk","rhs_acc_perst1ik"
+#define RIFLE_ATTACHMENTS "rhs_acc_dtk","rhs_acc_perst1ik"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define AR_ATTACHMENTS "CUP_optic_Kobra"
-#define ALT_OPTICS "rhs_acc_ekp1","rhs_acc_pkas"
+#define ALT_OPTICS WARSAW_OPTICS
 // GL Rifle
 #define GLRIFLE "rhs_weap_ak74m_gp25"
 #define GLRIFLE_MAG RIFLE_MAG
@@ -22,6 +21,7 @@
 // AR
 #define AR "CUP_arifle_RPK74"
 #define AR_MAG "CUP_75Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M:6"
+#define AR_ATTACHMENTS "CUP_optic_Kobra"
 // AT
 #define AT "rhs_weap_rpg26"
 // MMG

--- a/Loadouts/ru_ak74_floral.hpp
+++ b/Loadouts/ru_ak74_floral.hpp
@@ -6,10 +6,9 @@
 // Rifle
 #define RIFLE "rhs_weap_ak74m_camo","rhs_weap_ak74m_2mag_camo","rhs_weap_ak74m","rhs_weap_ak74m_2mag"
 #define RIFLE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
-#define RIFLE_ATTACHMENTS "rhs_acc_1p63","rhs_acc_dtk","rhs_acc_perst1ik"
+#define RIFLE_ATTACHMENTS "rhs_acc_dtk","rhs_acc_perst1ik"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define AR_ATTACHMENTS "CUP_optic_Kobra"
-#define ALT_OPTICS "rhs_acc_ekp1","rhs_acc_pkas"
+#define ALT_OPTICS WARSAW_OPTICS
 // GL Rifle
 #define GLRIFLE "rhs_weap_ak74m_gp25"
 #define GLRIFLE_MAG RIFLE_MAG
@@ -22,6 +21,7 @@
 // AR
 #define AR "CUP_arifle_RPK74"
 #define AR_MAG "CUP_75Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M:6"
+#define AR_ATTACHMENTS "CUP_optic_Kobra"
 // AT
 #define AT "rhs_weap_rpg26"
 // MMG
@@ -119,6 +119,7 @@ class Soldier_AR_F: Soldier_F {// AR
   magazines[] = {AR_MAG,PISTOL_MAG,BASE_GRENADES};
   handguns[] = {PISTOL};
   attachments[] = {AR_ATTACHMENTS};
+  opticChoices[] = {};
 };
 class Soldier_AAR_F: Soldier_F {// AAR
   backpack[] = {"B_Kitbag_sgg"};

--- a/Loadouts/ukr_ak74_ddpm.hpp
+++ b/Loadouts/ukr_ak74_ddpm.hpp
@@ -4,21 +4,23 @@
 #include "undef.hpp" // Reset defines
 
 // Rifle
-#define RIFLE "CUP_arifle_AK74"
-#define RIFLE_MAG "CUP_30Rnd_545x39_AK_M:8","CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M:2"
-#define RIFLE_ATTACHMENTS "CUP_optic_Kobra"
+#define RIFLE "rhs_weap_ak74n"
+#define RIFLE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
+#define RIFLE_ATTACHMENTS "rhs_acc_dtk","rhs_acc_perst1ik"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
+#define ALT_OPTICS WARSAW_OPTICS
 // GL Rifle
-#define GLRIFLE "CUP_arifle_AK74_GL"
+#define GLRIFLE "rhs_weap_ak74n_gp25","rhs_weap_aks74n_gp25"
 #define GLRIFLE_MAG RIFLE_MAG
-#define GLRIFLE_MAG_SMOKE "CUP_1Rnd_SMOKE_GP25_M:2","CUP_1Rnd_SmokeRed_GP25_M:2"
-#define GLRIFLE_MAG_HE "CUP_1Rnd_HE_GP25_M:5"
+#define GLRIFLE_MAG_SMOKE "rhs_GRD40_White:2","rhs_GRD40_Red:2"
+#define GLRIFLE_MAG_HE "rhs_VOG25:5"
 // Carbine
-#define CARBINE "CUP_arifle_AKS74"
+#define CARBINE "rhs_weap_aks74n"
 #define CARBINE_MAG RIFLE_MAG
 // AR
-#define AR "CUP_arifle_RPK74_45"
-#define AR_MAG "CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M:9"
+#define AR "CUP_arifle_RPK74"
+#define AR_MAG "CUP_75Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M:6"
+#define AR_ATTACHMENTS "CUP_optic_Kobra"
 // AT
 #define AT "rhs_weap_rpg7"
 #define AT_MAG "rhs_rpg7_PG7VL_mag:1"
@@ -84,6 +86,7 @@ class Soldier_F {// rifleman
   items[] = {BASE_TOOLS};
   linkedItems[] = {BASE_LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
+  opticChoices[] = {ALT_OPTICS};
 };
 class Fic_Soldier_Carbine: Soldier_F {// carbine-man
   weapons[] = {CARBINE};
@@ -113,6 +116,8 @@ class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
   magazines[] = {AR_MAG,PISTOL_MAG,BASE_GRENADES};
   handguns[] = {PISTOL};
+  attachments[] = {AR_ATTACHMENTS};
+  opticChoices[] = {};
 };
 class Soldier_AAR_F: Soldier_F {// AAR
   backpackItems[] += {AR_MAG};

--- a/Loadouts/ukr_ak74_ttsko.hpp
+++ b/Loadouts/ukr_ak74_ttsko.hpp
@@ -4,21 +4,23 @@
 #include "undef.hpp" // Reset defines
 
 // Rifle
-#define RIFLE "CUP_arifle_AK74"
-#define RIFLE_MAG "CUP_30Rnd_545x39_AK_M:8","CUP_30Rnd_TE1_Green_Tracer_545x39_AK_M:2"
-#define RIFLE_ATTACHMENTS "CUP_optic_Kobra"
+#define RIFLE "rhs_weap_ak74n"
+#define RIFLE_MAG "rhs_30Rnd_545x39_AK:8","rhs_30Rnd_545x39_AK_green:2"
+#define RIFLE_ATTACHMENTS "rhs_acc_dtk","rhs_acc_perst1ik"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
+#define ALT_OPTICS WARSAW_OPTICS
 // GL Rifle
-#define GLRIFLE "CUP_arifle_AK74_GL"
+#define GLRIFLE "rhs_weap_ak74n_gp25","rhs_weap_aks74n_gp25"
 #define GLRIFLE_MAG RIFLE_MAG
-#define GLRIFLE_MAG_SMOKE "CUP_1Rnd_SMOKE_GP25_M:2","CUP_1Rnd_SmokeRed_GP25_M:2"
-#define GLRIFLE_MAG_HE "CUP_1Rnd_HE_GP25_M:5"
+#define GLRIFLE_MAG_SMOKE "rhs_GRD40_White:2","rhs_GRD40_Red:2"
+#define GLRIFLE_MAG_HE "rhs_VOG25:5"
 // Carbine
-#define CARBINE "CUP_arifle_AKS74"
+#define CARBINE "rhs_weap_aks74n"
 #define CARBINE_MAG RIFLE_MAG
 // AR
-#define AR "CUP_arifle_RPK74_45"
-#define AR_MAG "CUP_45Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M:9"
+#define AR "CUP_arifle_RPK74"
+#define AR_MAG "CUP_75Rnd_TE4_LRT4_Green_Tracer_545x39_RPK_M:6"
+#define AR_ATTACHMENTS "CUP_optic_Kobra"
 // AT
 #define AT "rhs_weap_rpg7"
 #define AT_MAG "rhs_rpg7_PG7VL_mag:1"
@@ -84,6 +86,7 @@ class Soldier_F {// rifleman
   items[] = {BASE_TOOLS};
   linkedItems[] = {BASE_LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
+  opticChoices[] = {ALT_OPTICS};
 };
 class Fic_Soldier_Carbine: Soldier_F {// carbine-man
   weapons[] = {CARBINE};
@@ -113,6 +116,8 @@ class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
   magazines[] = {AR_MAG,PISTOL_MAG,BASE_GRENADES};
   handguns[] = {PISTOL};
+  attachments[] = {AR_ATTACHMENTS};
+  opticChoices[] = {};
 };
 class Soldier_AAR_F: Soldier_F {// AAR
   backpackItems[] += {AR_MAG};

--- a/Loadouts/us_m4_ocp.hpp
+++ b/Loadouts/us_m4_ocp.hpp
@@ -6,9 +6,9 @@
 // Rifle
 #define RIFLE "rhs_weap_m4a1_carryhandle_grip2"
 #define RIFLE_MAG "rhs_mag_30Rnd_556x45_Mk318_Stanag:8","rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red:2"
-#define RIFLE_ATTACHMENTS "CUP_optic_HoloBlack","rhsusf_acc_anpeq15A"
+#define RIFLE_ATTACHMENTS "rhsusf_acc_anpeq15A"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define ALT_OPTICS "optic_Aco","rhsusf_acc_compm4","rhsusf_acc_eotech_xps3","CUP_optic_CompM2_Black","CUP_optic_TrijiconRx01_black","CUP_optic_MRad"
+#define ALT_OPTICS STANAG_OPTICS
 // GL Rifle
 #define GLRIFLE "rhs_weap_m4a1_carryhandle_m203S"
 #define GLRIFLE_MAG RIFLE_MAG

--- a/Loadouts/us_m4_ucp.hpp
+++ b/Loadouts/us_m4_ucp.hpp
@@ -6,9 +6,9 @@
 // Rifle
 #define RIFLE "rhs_weap_m4a1_carryhandle_grip2"
 #define RIFLE_MAG "rhs_mag_30Rnd_556x45_Mk318_Stanag:8","rhs_mag_30Rnd_556x45_M855A1_Stanag_Tracer_Red:2"
-#define RIFLE_ATTACHMENTS "CUP_optic_HoloBlack","rhsusf_acc_anpeq15A"
+#define RIFLE_ATTACHMENTS "rhsusf_acc_anpeq15A"
 #define AAR_ATTACHMENTS RIFLE_ATTACHMENTS
-#define ALT_OPTICS "optic_Aco","rhsusf_acc_compm4","rhsusf_acc_eotech_xps3","CUP_optic_CompM2_Black","CUP_optic_TrijiconRx01_black","CUP_optic_MRad"
+#define ALT_OPTICS STANAG_OPTICS
 // GL Rifle
 #define GLRIFLE "rhs_weap_m4a1_carryhandle_m203S"
 #define GLRIFLE_MAG RIFLE_MAG


### PR DESCRIPTION
This PR will:
- Change the default BluFor loadout to OCP to hopefully prevent grey men attacking through a green forest
- Attempt to commonize alternate optics to (rhs) warsaw / picatinny rail systems. Should load in with ironsights, then choose whatever they can use.
- Convert all AK weapons to use versions that can mount sight (I think the only one un-fixed is reb M-70s)
- Convert ukr to use 75 round drums instead of 45 banana mags