### PR TITLE
Move (most) ACE settings to CBA

### DIFF
--- a/cfg/ACE_Settings.hpp
+++ b/cfg/ACE_Settings.hpp
@@ -1,15 +1,5 @@
 // ACE Settings: (see http://forums.bourbonwarfare.com/viewtopic.php?f=8&t=2026)
 class ACE_Settings {
-  /*   Run potato briefings at start up   */
-  class potato_briefing_brief_addCredits {
-    typeName = "BOOL";
-    value = 1;
-  };
-  class potato_briefing_brief_addOrbat {
-    typeName = "BOOL";
-    value = 1;
-  };
-
   /*   Enable potato markers   */
   class potato_markers_groupAndUnitEnabled {
     typeName = "BOOL";
@@ -18,89 +8,5 @@ class ACE_Settings {
   class potato_markers_intraFireteamEnabled {
     typeName = "BOOL";
     value = 1;
-  };
-
-  /*   Start safestart on mission start   */
-  class potato_safeStart_enabled {
-    typeName = "BOOL";
-    value = 1;
-  };
-
-  /*   Setup AI skills   */
-  class potato_missionModules_aiSkill_set {
-    typeName = "BOOL";
-    value = 1;
-  };
-  class potato_missionModules_aiSkill_aimingAccuracy_min {
-    typeName = "SCALAR";
-    value = 0.25;
-  };
-  class potato_missionModules_aiSkill_aimingAccuracy_max {
-    typeName = "SCALAR";
-    value = 0.60;
-  };
-  class potato_missionModules_aiSkill_aimingShake_min {
-    typeName = "SCALAR";
-    value = 0.6;
-  };
-  class potato_missionModules_aiSkill_aimingShake_max {
-    typeName = "SCALAR";
-    value = 0.9;
-  };
-  class potato_missionModules_aiSkill_aimingSpeed_min {
-    typeName = "SCALAR";
-    value = 0.3;
-  };
-  class potato_missionModules_aiSkill_aimingSpeed_max {
-    typeName = "SCALAR";
-    value = 0.7;
-  };
-  class potato_missionModules_aiSkill_commanding_min {
-    typeName = "SCALAR";
-    value = 0.7;
-  };
-  class potato_missionModules_aiSkill_commanding_max {
-    typeName = "SCALAR";
-    value = 1;
-  };
-  class potato_missionModules_aiSkill_courage_min {
-    typeName = "SCALAR";
-    value = 0.8;
-  };
-  class potato_missionModules_aiSkill_courage_max {
-    typeName = "SCALAR";
-    value = 1;
-  };
-  class potato_missionModules_aiSkill_general_min {
-    typeName = "SCALAR";
-    value = 0.7;
-  };
-  class potato_missionModules_aiSkill_general_max {
-    typeName = "SCALAR";
-    value = 1;
-  };
-  class potato_missionModules_aiSkill_reloadSpeed_min {
-    typeName = "SCALAR";
-    value = 0.5;
-  };
-  class potato_missionModules_aiSkill_reloadSpeed_max {
-    typeName = "SCALAR";
-    value = 0.8;
-  };
-  class potato_missionModules_aiSkill_spotDistance_min {
-    typeName = "SCALAR";
-    value = 0.8;
-  };
-  class potato_missionModules_aiSkill_spotDistance_max {
-    typeName = "SCALAR";
-    value = 1;
-  };
-  class potato_missionModules_aiSkill_spotTime_min {
-    typeName = "SCALAR";
-    value = 0.3;
-  };
-  class potato_missionModules_aiSkill_spotTime_max {
-    typeName = "SCALAR";
-    value = 0.7;
   };
 };

--- a/cfg/CfgEventHandlers.hpp
+++ b/cfg/CfgEventHandlers.hpp
@@ -1,8 +1,5 @@
 //Extended Event Handlers:
 class Extended_InitPost_EventHandlers {
-  class CAManBase {
-    class BWMF_FixFriendlyFire { init = "if (local (_this select 0)) then {(_this select 0) addRating 100000;};";};
-  };
   class Car {
     class BWMF_NoBitchZone { init = "(_this select 0) allowCrewInImmobile true;"; };
     class BWMF_DisableThermals { init = "(_this select 0) disableTIEquipment true;"; };

--- a/description.ext
+++ b/description.ext
@@ -15,7 +15,7 @@ onLoadName = "*** Insert mission name here. ***";
 
 respawnDelay = 5; // wait 5 seconds to go to spec
 
-bwmfDate = "2017/12/17"; //Framework date
+bwmfDate = "2018/02/18"; //Framework date
 
 class CfgDebriefingSections {
   class acex_killTracker {

--- a/mission.sqm
+++ b/mission.sqm
@@ -18,23 +18,20 @@ class EditorData
 		aside[]={-0.99997205,9.8206783e-008,-0.013679621};
 	};
 };
-binarizationWanted=0;
+binarizationWanted=1;
 addons[]=
 {
 	"A3_Characters_F",
-	"ace_explosives",
-	"cba_xeh",
 	"A3_Characters_F_Exp_Civil",
 	"A3_Modules_F_Curator_Curator",
 	"potato_units",
-	"Desert",
 	"potato_spectate"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=7;
+		items=5;
 		class Item0
 		{
 			className="A3_Characters_F";
@@ -44,37 +41,25 @@ class AddonsMetaData
 		};
 		class Item1
 		{
-			className="ace_explosives";
-			name="ACE3 - Explosives";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item2
-		{
 			className="A3_Characters_F_Exp";
 			name="Arma 3 Apex - Characters and Clothing";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item3
+		class Item2
 		{
 			className="A3_Modules_F_Curator";
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item4
+		class Item3
 		{
 			className="potato_units";
 			name="potato_units";
 			author="Potato";
 		};
-		class Item5
-		{
-			className="Desert";
-			name="Desert";
-		};
-		class Item6
+		class Item4
 		{
 			className="potato_spectate";
 			name="potato_spectate";
@@ -206,7 +191,7 @@ class CustomAttributes
 										"STRING"
 									};
 								};
-								value="ar";
+								value="ar,en,ru";
 							};
 						};
 						class Item5
@@ -448,82 +433,6 @@ class CustomAttributes
 		};
 		class Attribute1
 		{
-			property="ReviveRequiredTrait";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"SCALAR"
-						};
-					};
-					value=0;
-				};
-			};
-		};
-		class Attribute2
-		{
-			property="ReviveMode";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"SCALAR"
-						};
-					};
-					value=0;
-				};
-			};
-		};
-		class Attribute3
-		{
-			property="ReviveMedicSpeedMultiplier";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"SCALAR"
-						};
-					};
-					value=2;
-				};
-			};
-		};
-		class Attribute4
-		{
-			property="SharedObjectives";
-			expression="if (isMultiplayer) then {[_value] spawn bis_fnc_sharedObjectives;};";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"SCALAR"
-						};
-					};
-					value=0;
-				};
-			};
-		};
-		class Attribute5
-		{
 			property="RespawnButton";
 			expression="true";
 			class Value
@@ -541,102 +450,7 @@ class CustomAttributes
 				};
 			};
 		};
-		class Attribute6
-		{
-			property="ReviveForceRespawnDelay";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"SCALAR"
-						};
-					};
-					value=3;
-				};
-			};
-		};
-		class Attribute7
-		{
-			property="ReviveBleedOutDelay";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"SCALAR"
-						};
-					};
-					value=20;
-				};
-			};
-		};
-		class Attribute8
-		{
-			property="ReviveDelay";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"SCALAR"
-						};
-					};
-					value=6;
-				};
-			};
-		};
-		class Attribute9
-		{
-			property="ReviveUnconsciousStateMode";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"SCALAR"
-						};
-					};
-					value=0;
-				};
-			};
-		};
-		class Attribute10
-		{
-			property="ReviveRequiredItems";
-			expression="false";
-			class Value
-			{
-				class data
-				{
-					class type
-					{
-						type[]=
-						{
-							"SCALAR"
-						};
-					};
-					value=0;
-				};
-			};
-		};
-		nAttributes=11;
+		nAttributes=2;
 	};
 	class Category3
 	{

--- a/mission.sqm
+++ b/mission.sqm
@@ -12,13 +12,13 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={653.41669,99.807922,1059.6511};
+		pos[]={681.00555,91.308769,1032.2285};
 		dir[]={0.044078793,-0.46208301,-0.88581848};
 		up[]={0.022972254,0.88676476,-0.4616352};
 		aside[]={-0.99882543,-3.9188308e-008,-0.049701821};
 	};
 };
-binarizationWanted=1;
+binarizationWanted=0;
 addons[]=
 {
 	"A3_Characters_F",
@@ -30,13 +30,14 @@ addons[]=
 	"ace_mk6mortar",
 	"A3_Modules_F_Curator_Curator",
 	"ace_refuel",
-	"potato_units"
+	"potato_units",
+	"Desert"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=9;
+		items=10;
 		class Item0
 		{
 			className="A3_Characters_F";
@@ -98,6 +99,11 @@ class AddonsMetaData
 			className="potato_units";
 			name="potato_units";
 			author="Potato";
+		};
+		class Item9
+		{
+			className="Desert";
+			name="Desert";
 		};
 	};
 };
@@ -404,6 +410,30 @@ class CustomAttributes
 	};
 	class Category1
 	{
+		name="potato_briefing_briefings";
+		class Attribute0
+		{
+			property="potato_briefing_briefingSettingsValue";
+			expression="[nil,_value] call potato_briefing_fnc_briefingSettingsAttributeLoad";
+			class Value
+			{
+				class data
+				{
+					class type
+					{
+						type[]=
+						{
+							"STRING"
+						};
+					};
+					value="true,true";
+				};
+			};
+		};
+		nAttributes=1;
+	};
+	class Category2
+	{
 		name="Multiplayer";
 		class Attribute0
 		{
@@ -633,7 +663,7 @@ class CustomAttributes
 		};
 		nAttributes=11;
 	};
-	class Category2
+	class Category3
 	{
 		name="Scenario";
 		class Attribute0
@@ -681,7 +711,7 @@ class CustomAttributes
 								};
 								class value
 								{
-									items=6;
+									items=8;
 									class Item0
 									{
 										class data
@@ -766,6 +796,34 @@ class CustomAttributes
 											value="acre_sys_core_terrainloss";
 										};
 									};
+									class Item6
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="potato_missionmodules_aiskill_set";
+										};
+									};
+									class Item7
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="potato_safestart_enabled";
+										};
+									};
 								};
 							};
 						};
@@ -782,7 +840,7 @@ class CustomAttributes
 								};
 								class value
 								{
-									items=6;
+									items=8;
 									class Item0
 									{
 										class data
@@ -1034,6 +1092,96 @@ class CustomAttributes
 															};
 														};
 														value=0.25289679;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item6
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item7
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
 													};
 												};
 												class Item1

--- a/mission.sqm
+++ b/mission.sqm
@@ -12,10 +12,10 @@ class EditorData
 	};
 	class Camera
 	{
-		pos[]={681.00555,91.308769,1032.2285};
-		dir[]={0.044078793,-0.46208301,-0.88581848};
-		up[]={0.022972254,0.88676476,-0.4616352};
-		aside[]={-0.99882543,-3.9188308e-008,-0.049701821};
+		pos[]={625.82648,14.75275,857.21881};
+		dir[]={-0.0034407747,-0.74945903,-0.66214812};
+		up[]={-0.0038936853,0.66196895,-0.74951094};
+		aside[]={-1.0000472,4.7287585e-008,0.0051968195};
 	};
 };
 binarizationWanted=0;
@@ -25,11 +25,7 @@ addons[]=
 	"ace_explosives",
 	"cba_xeh",
 	"A3_Characters_F_Exp_Civil",
-	"ace_medical",
-	"ace_finger",
-	"ace_mk6mortar",
 	"A3_Modules_F_Curator_Curator",
-	"ace_refuel",
 	"potato_units",
 	"Desert"
 };
@@ -37,7 +33,7 @@ class AddonsMetaData
 {
 	class List
 	{
-		items=10;
+		items=6;
 		class Item0
 		{
 			className="A3_Characters_F";
@@ -61,46 +57,18 @@ class AddonsMetaData
 		};
 		class Item3
 		{
-			className="ace_medical";
-			name="ACE3 - Medical";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item4
-		{
-			className="ace_finger";
-			name="ACE3 - Finger";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item5
-		{
-			className="ace_mk6mortar";
-			name="ACE3 - Mk6 Mortar";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item6
-		{
 			className="A3_Modules_F_Curator";
 			name="Arma 3 Zeus Update - Scripted Modules";
 			author="Bohemia Interactive";
 			url="https://www.arma3.com";
 		};
-		class Item7
-		{
-			className="ace_refuel";
-			name="ACE3 - Refuel";
-			author="ACE-Team";
-			url="http://ace3mod.com/";
-		};
-		class Item8
+		class Item4
 		{
 			className="potato_units";
 			name="potato_units";
 			author="Potato";
 		};
-		class Item9
+		class Item5
 		{
 			className="Desert";
 			name="Desert";
@@ -711,7 +679,7 @@ class CustomAttributes
 								};
 								class value
 								{
-									items=8;
+									items=28;
 									class Item0
 									{
 										class data
@@ -824,6 +792,286 @@ class CustomAttributes
 											value="potato_safestart_enabled";
 										};
 									};
+									class Item8
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_refuel_rate";
+										};
+									};
+									class Item9
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_finger_enabled";
+										};
+									};
+									class Item10
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_finger_maxrange";
+										};
+									};
+									class Item11
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_interaction_disablenegativerating";
+										};
+									};
+									class Item12
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_mk6mortar_airresistanceenabled";
+										};
+									};
+									class Item13
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_mk6mortar_allowcomputerrangefinder";
+										};
+									};
+									class Item14
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_level";
+										};
+									};
+									class Item15
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_medicsetting";
+										};
+									};
+									class Item16
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_bleedingcoefficient";
+										};
+									};
+									class Item17
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_enableunconsciousnessai";
+										};
+									};
+									class Item18
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_littercleanupdelay";
+										};
+									};
+									class Item19
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_medicsetting_pak";
+										};
+									};
+									class Item20
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_medicsetting_surgicalkit";
+										};
+									};
+									class Item21
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_consumeitem_pak";
+										};
+									};
+									class Item22
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_consumeitem_surgicalkit";
+										};
+									};
+									class Item23
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_usecondition_pak";
+										};
+									};
+									class Item24
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_usecondition_surgicalkit";
+										};
+									};
+									class Item25
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_healhitpointafteradvbandage";
+										};
+									};
+									class Item26
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_painisonlysuppressed";
+										};
+									};
+									class Item27
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"STRING"
+												};
+											};
+											value="ace_medical_ai_enabledfor";
+										};
+									};
 								};
 							};
 						};
@@ -840,7 +1088,7 @@ class CustomAttributes
 								};
 								class value
 								{
-									items=8;
+									items=28;
 									class Item0
 									{
 										class data
@@ -1201,6 +1449,906 @@ class CustomAttributes
 											};
 										};
 									};
+									class Item8
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=10;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item9
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item10
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=3;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item11
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item12
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item13
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=0;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item14
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=2;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item15
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=2;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item16
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1.5;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item17
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=0;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item18
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=300;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item19
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item20
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=2;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item21
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item22
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item23
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item24
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item25
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=1;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item26
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"BOOL"
+															};
+														};
+														value=0;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
+									class Item27
+									{
+										class data
+										{
+											class type
+											{
+												type[]=
+												{
+													"ARRAY"
+												};
+											};
+											class value
+											{
+												items=2;
+												class Item0
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=0;
+													};
+												};
+												class Item1
+												{
+													class data
+													{
+														class type
+														{
+															type[]=
+															{
+																"SCALAR"
+															};
+														};
+														value=1;
+													};
+												};
+											};
+										};
+									};
 								};
 							};
 						};
@@ -1269,7 +2417,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=179;
+		items=174;
 		class Item0
 		{
 			dataType="Group";
@@ -8891,428 +10039,6 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={621.95856,5,847.97003};
-			};
-			id=702;
-			type="ACE_moduleMedicalSettings";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ACE_moduleMedicalSettings_litterCleanUpDelay";
-					expression="_this setVariable ['litterCleanUpDelay',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=300;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ACE_moduleMedicalSettings_enableScreams";
-					expression="_this setVariable ['enableScreams',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="ACE_moduleMedicalSettings_preventInstaDeath";
-					expression="_this setVariable ['preventInstaDeath',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute3
-				{
-					property="ACE_moduleMedicalSettings_bleedingCoefficient";
-					expression="_this setVariable ['bleedingCoefficient',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1.25;
-						};
-					};
-				};
-				class Attribute4
-				{
-					property="ACE_moduleMedicalSettings_increaseTrainingInLocations";
-					expression="_this setVariable ['increaseTrainingInLocations',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute5
-				{
-					property="ACE_moduleMedicalSettings_enableUnconsciousnessAI";
-					expression="_this setVariable ['enableUnconsciousnessAI',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute6
-				{
-					property="ACE_moduleMedicalSettings_remoteControlledAI";
-					expression="_this setVariable ['remoteControlledAI',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute7
-				{
-					property="ACE_moduleMedicalSettings_painCoefficient";
-					expression="_this setVariable ['painCoefficient',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute8
-				{
-					property="ACE_moduleMedicalSettings_AIDamageThreshold";
-					expression="_this setVariable ['AIDamageThreshold',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute9
-				{
-					property="ACE_moduleMedicalSettings_playerDamageThreshold";
-					expression="_this setVariable ['playerDamageThreshold',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute10
-				{
-					property="ACE_moduleMedicalSettings_level";
-					expression="_this setVariable ['level',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=2;
-						};
-					};
-				};
-				class Attribute11
-				{
-					property="ACE_moduleMedicalSettings_allowLitterCreation";
-					expression="_this setVariable ['allowLitterCreation',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute12
-				{
-					property="ACE_moduleMedicalSettings_keepLocalSettingsSynced";
-					expression="_this setVariable ['keepLocalSettingsSynced',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute13
-				{
-					property="ACE_moduleMedicalSettings_medicSetting";
-					expression="_this setVariable ['medicSetting',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=2;
-						};
-					};
-				};
-				nAttributes=14;
-			};
-		};
-		class Item45
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={625.9173,5,847.91278};
-			};
-			id=703;
-			type="ace_finger_moduleSettings";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ace_finger_moduleSettings_maxRange";
-					expression="_this setVariable ['maxRange',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=3;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ace_finger_moduleSettings_enabled";
-					expression="_this setVariable ['enabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				nAttributes=2;
-			};
-		};
-		class Item46
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={623.88959,5,847.95477};
-			};
-			id=704;
-			type="ace_mk6mortar_module";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ace_mk6mortar_module_allowCompass";
-					expression="_this setVariable ['allowCompass',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ace_mk6mortar_module_airResistanceEnabled";
-					expression="_this setVariable ['airResistanceEnabled',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="ace_mk6mortar_module_allowComputerRangefinder";
-					expression="_this setVariable ['allowComputerRangefinder',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute3
-				{
-					property="ace_mk6mortar_module_useAmmoHandling";
-					expression="_this setVariable ['useAmmoHandling',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				nAttributes=4;
-			};
-		};
-		class Item47
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
 				position[]={621.93506,5,849.95935};
 			};
 			name="bwmf_placedZeus_1";
@@ -9418,59 +10144,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item48
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={627.89569,5,847.84412};
-			};
-			id=706;
-			type="ACE_moduleRefuelSettings";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ACE_moduleRefuelSettings_rate";
-					expression="_this setVariable ['rate',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=10;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ACE_moduleRefuelSettings_hoseLength";
-					expression="_this setVariable ['hoseLength',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=12;
-						};
-					};
-				};
-				nAttributes=2;
-			};
-		};
-		class Item49
+		class Item45
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9580,7 +10254,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item50
+		class Item46
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -9690,7 +10364,7 @@ class Mission
 				nAttributes=5;
 			};
 		};
-		class Item51
+		class Item47
 		{
 			dataType="Group";
 			side="West";
@@ -10442,7 +11116,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item52
+		class Item48
 		{
 			dataType="Group";
 			side="Independent";
@@ -10658,7 +11332,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item53
+		class Item49
 		{
 			dataType="Group";
 			side="Independent";
@@ -10814,7 +11488,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item54
+		class Item50
 		{
 			dataType="Group";
 			side="Independent";
@@ -10969,7 +11643,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item55
+		class Item51
 		{
 			dataType="Group";
 			side="Independent";
@@ -11109,7 +11783,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item56
+		class Item52
 		{
 			dataType="Group";
 			side="Independent";
@@ -11385,7 +12059,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item57
+		class Item53
 		{
 			dataType="Group";
 			side="Independent";
@@ -11661,7 +12335,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item58
+		class Item54
 		{
 			dataType="Group";
 			side="Independent";
@@ -11801,7 +12475,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item59
+		class Item55
 		{
 			dataType="Group";
 			side="Independent";
@@ -12077,7 +12751,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item60
+		class Item56
 		{
 			dataType="Group";
 			side="Independent";
@@ -12353,7 +13027,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item61
+		class Item57
 		{
 			dataType="Group";
 			side="Independent";
@@ -12493,7 +13167,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item62
+		class Item58
 		{
 			dataType="Group";
 			side="Independent";
@@ -12769,7 +13443,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item63
+		class Item59
 		{
 			dataType="Group";
 			side="Independent";
@@ -13045,7 +13719,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item64
+		class Item60
 		{
 			dataType="Group";
 			side="Independent";
@@ -13200,7 +13874,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item65
+		class Item61
 		{
 			dataType="Group";
 			side="Independent";
@@ -13355,7 +14029,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item66
+		class Item62
 		{
 			dataType="Group";
 			side="Independent";
@@ -13510,7 +14184,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item67
+		class Item63
 		{
 			dataType="Group";
 			side="Independent";
@@ -13665,7 +14339,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item68
+		class Item64
 		{
 			dataType="Group";
 			side="Independent";
@@ -13796,7 +14470,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item69
+		class Item65
 		{
 			dataType="Group";
 			side="Independent";
@@ -13927,7 +14601,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item70
+		class Item66
 		{
 			dataType="Group";
 			side="Independent";
@@ -14058,7 +14732,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item71
+		class Item67
 		{
 			dataType="Group";
 			side="Independent";
@@ -14189,7 +14863,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item72
+		class Item68
 		{
 			dataType="Group";
 			side="Independent";
@@ -14320,7 +14994,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item73
+		class Item69
 		{
 			dataType="Group";
 			side="Independent";
@@ -14437,7 +15111,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item74
+		class Item70
 		{
 			dataType="Group";
 			side="Independent";
@@ -14567,7 +15241,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item75
+		class Item71
 		{
 			dataType="Group";
 			side="Independent";
@@ -14697,7 +15371,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item76
+		class Item72
 		{
 			dataType="Group";
 			side="Independent";
@@ -14827,7 +15501,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item77
+		class Item73
 		{
 			dataType="Group";
 			side="Independent";
@@ -14957,7 +15631,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item78
+		class Item74
 		{
 			dataType="Group";
 			side="Independent";
@@ -15087,7 +15761,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item79
+		class Item75
 		{
 			dataType="Group";
 			side="Independent";
@@ -15217,7 +15891,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item80
+		class Item76
 		{
 			dataType="Group";
 			side="Independent";
@@ -15356,7 +16030,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item81
+		class Item77
 		{
 			dataType="Group";
 			side="Independent";
@@ -15468,7 +16142,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item82
+		class Item78
 		{
 			dataType="Group";
 			side="Independent";
@@ -15616,7 +16290,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item83
+		class Item79
 		{
 			dataType="Group";
 			side="Independent";
@@ -15756,7 +16430,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item84
+		class Item80
 		{
 			dataType="Group";
 			side="Independent";
@@ -16032,7 +16706,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item85
+		class Item81
 		{
 			dataType="Group";
 			side="Independent";
@@ -16308,7 +16982,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item86
+		class Item82
 		{
 			dataType="Group";
 			side="Independent";
@@ -16448,7 +17122,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item87
+		class Item83
 		{
 			dataType="Group";
 			side="Independent";
@@ -16724,7 +17398,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item88
+		class Item84
 		{
 			dataType="Group";
 			side="Independent";
@@ -17000,7 +17674,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item89
+		class Item85
 		{
 			dataType="Group";
 			side="Independent";
@@ -17140,7 +17814,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item90
+		class Item86
 		{
 			dataType="Group";
 			side="Independent";
@@ -17416,7 +18090,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item91
+		class Item87
 		{
 			dataType="Group";
 			side="Independent";
@@ -17692,7 +18366,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item92
+		class Item88
 		{
 			dataType="Group";
 			side="Independent";
@@ -18444,7 +19118,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item93
+		class Item89
 		{
 			dataType="Group";
 			side="East";
@@ -18660,7 +19334,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item94
+		class Item90
 		{
 			dataType="Group";
 			side="East";
@@ -18816,7 +19490,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item95
+		class Item91
 		{
 			dataType="Group";
 			side="East";
@@ -18971,7 +19645,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item96
+		class Item92
 		{
 			dataType="Group";
 			side="East";
@@ -19111,7 +19785,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item97
+		class Item93
 		{
 			dataType="Group";
 			side="East";
@@ -19387,7 +20061,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item98
+		class Item94
 		{
 			dataType="Group";
 			side="East";
@@ -19663,7 +20337,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item99
+		class Item95
 		{
 			dataType="Group";
 			side="East";
@@ -19803,7 +20477,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item100
+		class Item96
 		{
 			dataType="Group";
 			side="East";
@@ -20079,7 +20753,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item101
+		class Item97
 		{
 			dataType="Group";
 			side="East";
@@ -20355,7 +21029,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item102
+		class Item98
 		{
 			dataType="Group";
 			side="East";
@@ -20495,7 +21169,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item103
+		class Item99
 		{
 			dataType="Group";
 			side="East";
@@ -20771,7 +21445,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item104
+		class Item100
 		{
 			dataType="Group";
 			side="East";
@@ -21047,7 +21721,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item105
+		class Item101
 		{
 			dataType="Group";
 			side="East";
@@ -21202,7 +21876,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item106
+		class Item102
 		{
 			dataType="Group";
 			side="East";
@@ -21357,7 +22031,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item107
+		class Item103
 		{
 			dataType="Group";
 			side="East";
@@ -21512,7 +22186,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item108
+		class Item104
 		{
 			dataType="Group";
 			side="East";
@@ -21667,7 +22341,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item109
+		class Item105
 		{
 			dataType="Group";
 			side="East";
@@ -21798,7 +22472,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item110
+		class Item106
 		{
 			dataType="Group";
 			side="East";
@@ -21929,7 +22603,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item111
+		class Item107
 		{
 			dataType="Group";
 			side="East";
@@ -22060,7 +22734,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item112
+		class Item108
 		{
 			dataType="Group";
 			side="East";
@@ -22191,7 +22865,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item113
+		class Item109
 		{
 			dataType="Group";
 			side="East";
@@ -22322,7 +22996,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item114
+		class Item110
 		{
 			dataType="Group";
 			side="East";
@@ -22439,7 +23113,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item115
+		class Item111
 		{
 			dataType="Group";
 			side="East";
@@ -22569,7 +23243,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item116
+		class Item112
 		{
 			dataType="Group";
 			side="East";
@@ -22699,7 +23373,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item117
+		class Item113
 		{
 			dataType="Group";
 			side="East";
@@ -22829,7 +23503,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item118
+		class Item114
 		{
 			dataType="Group";
 			side="East";
@@ -22959,7 +23633,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item119
+		class Item115
 		{
 			dataType="Group";
 			side="East";
@@ -23089,7 +23763,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item120
+		class Item116
 		{
 			dataType="Group";
 			side="East";
@@ -23219,7 +23893,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item121
+		class Item117
 		{
 			dataType="Group";
 			side="East";
@@ -23358,7 +24032,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item122
+		class Item118
 		{
 			dataType="Group";
 			side="East";
@@ -23470,7 +24144,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item123
+		class Item119
 		{
 			dataType="Group";
 			side="East";
@@ -23618,7 +24292,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item124
+		class Item120
 		{
 			dataType="Group";
 			side="East";
@@ -23758,7 +24432,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item125
+		class Item121
 		{
 			dataType="Group";
 			side="East";
@@ -24034,7 +24708,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item126
+		class Item122
 		{
 			dataType="Group";
 			side="East";
@@ -24310,7 +24984,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item127
+		class Item123
 		{
 			dataType="Group";
 			side="East";
@@ -24450,7 +25124,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item128
+		class Item124
 		{
 			dataType="Group";
 			side="East";
@@ -24726,7 +25400,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item129
+		class Item125
 		{
 			dataType="Group";
 			side="East";
@@ -25002,7 +25676,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item130
+		class Item126
 		{
 			dataType="Group";
 			side="East";
@@ -25142,7 +25816,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item131
+		class Item127
 		{
 			dataType="Group";
 			side="East";
@@ -25418,7 +26092,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item132
+		class Item128
 		{
 			dataType="Group";
 			side="East";
@@ -25694,7 +26368,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item133
+		class Item129
 		{
 			dataType="Group";
 			side="East";
@@ -26446,7 +27120,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item134
+		class Item130
 		{
 			dataType="Group";
 			side="East";
@@ -26637,7 +27311,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item135
+		class Item131
 		{
 			dataType="Group";
 			side="East";
@@ -26750,7 +27424,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item136
+		class Item132
 		{
 			dataType="Group";
 			side="East";
@@ -26863,7 +27537,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item137
+		class Item133
 		{
 			dataType="Comment";
 			class PositionInfo
@@ -26873,7 +27547,7 @@ class Mission
 			title="Opfor Units";
 			id=1544;
 		};
-		class Item138
+		class Item134
 		{
 			dataType="Comment";
 			class PositionInfo
@@ -26883,7 +27557,7 @@ class Mission
 			title="Civilian Units";
 			id=1545;
 		};
-		class Item139
+		class Item135
 		{
 			dataType="Comment";
 			class PositionInfo
@@ -26893,7 +27567,7 @@ class Mission
 			title="Bluefor Units";
 			id=1546;
 		};
-		class Item140
+		class Item136
 		{
 			dataType="Comment";
 			class PositionInfo
@@ -26903,7 +27577,7 @@ class Mission
 			title="Independent Units";
 			id=1547;
 		};
-		class Item141
+		class Item137
 		{
 			dataType="Group";
 			side="East";
@@ -27016,7 +27690,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item142
+		class Item138
 		{
 			dataType="Group";
 			side="East";
@@ -27480,7 +28154,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item143
+		class Item139
 		{
 			dataType="Group";
 			side="East";
@@ -27940,7 +28614,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item144
+		class Item140
 		{
 			dataType="Group";
 			side="East";
@@ -28423,7 +29097,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item145
+		class Item141
 		{
 			dataType="Group";
 			side="East";
@@ -28906,7 +29580,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item146
+		class Item142
 		{
 			dataType="Comment";
 			class PositionInfo
@@ -28916,7 +29590,7 @@ class Mission
 			title="MSV Units";
 			id=2278;
 		};
-		class Item147
+		class Item143
 		{
 			dataType="Group";
 			side="East";
@@ -29399,7 +30073,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item148
+		class Item144
 		{
 			dataType="Group";
 			side="East";
@@ -29881,7 +30555,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item149
+		class Item145
 		{
 			dataType="Group";
 			side="East";
@@ -30363,7 +31037,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item150
+		class Item146
 		{
 			dataType="Group";
 			side="East";
@@ -30846,7 +31520,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item151
+		class Item147
 		{
 			dataType="Group";
 			side="East";
@@ -31329,7 +32003,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item152
+		class Item148
 		{
 			dataType="Group";
 			side="East";
@@ -31442,7 +32116,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item153
+		class Item149
 		{
 			dataType="Group";
 			side="East";
@@ -31554,7 +32228,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item154
+		class Item150
 		{
 			dataType="Group";
 			side="East";
@@ -31666,7 +32340,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item155
+		class Item151
 		{
 			dataType="Group";
 			side="East";
@@ -31778,7 +32452,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item156
+		class Item152
 		{
 			dataType="Group";
 			side="East";
@@ -31890,7 +32564,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item157
+		class Item153
 		{
 			dataType="Group";
 			side="East";
@@ -32002,7 +32676,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item158
+		class Item154
 		{
 			dataType="Group";
 			side="East";
@@ -32114,7 +32788,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item159
+		class Item155
 		{
 			dataType="Group";
 			side="East";
@@ -32226,7 +32900,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item160
+		class Item156
 		{
 			dataType="Group";
 			side="East";
@@ -32338,7 +33012,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item161
+		class Item157
 		{
 			dataType="Group";
 			side="East";
@@ -32450,7 +33124,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item162
+		class Item158
 		{
 			dataType="Group";
 			side="East";
@@ -32599,7 +33273,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item163
+		class Item159
 		{
 			dataType="Group";
 			side="East";
@@ -32747,7 +33421,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item164
+		class Item160
 		{
 			dataType="Group";
 			side="East";
@@ -32878,7 +33552,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item165
+		class Item161
 		{
 			dataType="Group";
 			side="East";
@@ -33009,7 +33683,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item166
+		class Item162
 		{
 			dataType="Group";
 			side="East";
@@ -33140,7 +33814,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item167
+		class Item163
 		{
 			dataType="Group";
 			side="East";
@@ -33271,7 +33945,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item168
+		class Item164
 		{
 			dataType="Group";
 			side="East";
@@ -33388,7 +34062,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item169
+		class Item165
 		{
 			dataType="Group";
 			side="East";
@@ -33505,7 +34179,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item170
+		class Item166
 		{
 			dataType="Group";
 			side="East";
@@ -33622,7 +34296,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item171
+		class Item167
 		{
 			dataType="Group";
 			side="East";
@@ -33739,7 +34413,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item172
+		class Item168
 		{
 			dataType="Group";
 			side="East";
@@ -33856,7 +34530,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item173
+		class Item169
 		{
 			dataType="Group";
 			side="East";
@@ -33973,7 +34647,7 @@ class Mission
 				nAttributes=2;
 			};
 		};
-		class Item174
+		class Item170
 		{
 			dataType="Group";
 			side="East";
@@ -34394,7 +35068,7 @@ class Mission
 				nAttributes=3;
 			};
 		};
-		class Item175
+		class Item171
 		{
 			dataType="Group";
 			side="East";
@@ -34807,7 +35481,7 @@ class Mission
 				nAttributes=1;
 			};
 		};
-		class Item176
+		class Item172
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -34819,7 +35493,7 @@ class Mission
 			id=2915;
 			type="HeadlessClient_F";
 		};
-		class Item177
+		class Item173
 		{
 			dataType="Logic";
 			class PositionInfo
@@ -34830,267 +35504,6 @@ class Mission
 			isPlayable=1;
 			id=2916;
 			type="HeadlessClient_F";
-		};
-		class Item178
-		{
-			dataType="Logic";
-			class PositionInfo
-			{
-				position[]={619.89056,5,848.02899};
-			};
-			id=2917;
-			type="ACE_moduleAdvancedMedicalSettings";
-			class CustomAttributes
-			{
-				class Attribute0
-				{
-					property="ACE_moduleAdvancedMedicalSettings_enableVehicleCrashes";
-					expression="_this setVariable ['enableVehicleCrashes',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute1
-				{
-					property="ACE_moduleAdvancedMedicalSettings_consumeItem_SurgicalKit";
-					expression="_this setVariable ['consumeItem_SurgicalKit',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute2
-				{
-					property="ACE_moduleAdvancedMedicalSettings_enableAdvancedWounds";
-					expression="_this setVariable ['enableAdvancedWounds',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute3
-				{
-					property="ACE_moduleAdvancedMedicalSettings_consumeItem_PAK";
-					expression="_this setVariable ['consumeItem_PAK',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute4
-				{
-					property="ACE_moduleAdvancedMedicalSettings_useCondition_PAK";
-					expression="_this setVariable ['useCondition_PAK',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute5
-				{
-					property="ACE_moduleAdvancedMedicalSettings_medicSetting_PAK";
-					expression="_this setVariable ['medicSetting_PAK',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute6
-				{
-					property="ACE_moduleAdvancedMedicalSettings_medicSetting_SurgicalKit";
-					expression="_this setVariable ['medicSetting_SurgicalKit',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=2;
-						};
-					};
-				};
-				class Attribute7
-				{
-					property="ACE_moduleAdvancedMedicalSettings_healHitPointAfterAdvBandage";
-					expression="_this setVariable ['healHitPointAfterAdvBandage',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute8
-				{
-					property="ACE_moduleAdvancedMedicalSettings_useLocation_SurgicalKit";
-					expression="_this setVariable ['useLocation_SurgicalKit',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=2;
-						};
-					};
-				};
-				class Attribute9
-				{
-					property="ACE_moduleAdvancedMedicalSettings_useCondition_SurgicalKit";
-					expression="_this setVariable ['useCondition_SurgicalKit',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=1;
-						};
-					};
-				};
-				class Attribute10
-				{
-					property="ACE_moduleAdvancedMedicalSettings_useLocation_PAK";
-					expression="_this setVariable ['useLocation_PAK',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=2;
-						};
-					};
-				};
-				class Attribute11
-				{
-					property="ACE_moduleAdvancedMedicalSettings_enableFor";
-					expression="_this setVariable ['enableFor',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"SCALAR"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				class Attribute12
-				{
-					property="ACE_moduleAdvancedMedicalSettings_painIsOnlySuppressed";
-					expression="_this setVariable ['painIsOnlySuppressed',_value,true];";
-					class Value
-					{
-						class data
-						{
-							class type
-							{
-								type[]=
-								{
-									"BOOL"
-								};
-							};
-							value=0;
-						};
-					};
-				};
-				nAttributes=13;
-			};
 		};
 	};
 };

--- a/mission.sqm
+++ b/mission.sqm
@@ -8,14 +8,14 @@ class EditorData
 	toggles=513;
 	class ItemIDProvider
 	{
-		nextID=2918;
+		nextID=2924;
 	};
 	class Camera
 	{
-		pos[]={625.82648,14.75275,857.21881};
-		dir[]={-0.0034407747,-0.74945903,-0.66214812};
-		up[]={-0.0038936853,0.66196895,-0.74951094};
-		aside[]={-1.0000472,4.7287585e-008,0.0051968195};
+		pos[]={627.14044,250.03777,1073.9941};
+		dir[]={0.0093867658,-0.72748893,-0.6861648};
+		up[]={0.0099533107,0.68602955,-0.72749609};
+		aside[]={-0.99997205,9.8206783e-008,-0.013679621};
 	};
 };
 binarizationWanted=0;
@@ -27,13 +27,14 @@ addons[]=
 	"A3_Characters_F_Exp_Civil",
 	"A3_Modules_F_Curator_Curator",
 	"potato_units",
-	"Desert"
+	"Desert",
+	"potato_spectate"
 };
 class AddonsMetaData
 {
 	class List
 	{
-		items=6;
+		items=7;
 		class Item0
 		{
 			className="A3_Characters_F";
@@ -72,6 +73,12 @@ class AddonsMetaData
 		{
 			className="Desert";
 			name="Desert";
+		};
+		class Item6
+		{
+			className="potato_spectate";
+			name="potato_spectate";
+			author="Potato";
 		};
 	};
 };
@@ -2417,7 +2424,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=174;
+		items=180;
 		class Item0
 		{
 			dataType="Group";
@@ -10039,7 +10046,7 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={621.93506,5,849.95935};
+				position[]={626.01904,5,849.99756};
 			};
 			name="bwmf_placedZeus_1";
 			id=705;
@@ -10149,7 +10156,7 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={623.97205,5,849.90137};
+				position[]={623.99951,5,849.98822};
 			};
 			name="bwmf_placedZeus_2";
 			id=707;
@@ -10259,7 +10266,7 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={625.98102,5,849.87836};
+				position[]={621.93927,5,850.02869};
 			};
 			name="bwmf_placedZeus_3";
 			id=708;
@@ -35486,7 +35493,7 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={623.00403,5,852.02258};
+				position[]={625.98206,5,852.00507};
 			};
 			name="HC_SLOT_1";
 			isPlayable=1;
@@ -35498,12 +35505,187 @@ class Mission
 			dataType="Logic";
 			class PositionInfo
 			{
-				position[]={624.99402,5,851.98456};
+				position[]={623.97174,5,852.01556};
 			};
 			name="HC_SLOT_2";
 			isPlayable=1;
 			id=2916;
 			type="HeadlessClient_F";
+		};
+		class Item174
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={620.008,5,850};
+			};
+			name="bwmf_placedZeus_4";
+			id=2918;
+			type="ModuleCurator_F";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="ModuleCurator_F_Owner";
+					expression="_this setVariable ['Owner',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="ModuleCurator_F_Forced";
+					expression="_this setVariable ['Forced',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=0;
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="ModuleCurator_F_Name";
+					expression="_this setVariable ['Name',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"STRING"
+								};
+							};
+							value="";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="ModuleInfo";
+					expression="false";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"BOOL"
+								};
+							};
+							value=1;
+						};
+					};
+				};
+				class Attribute4
+				{
+					property="ModuleCurator_F_Addons";
+					expression="_this setVariable ['Addons',_value,true];";
+					class Value
+					{
+						class data
+						{
+							class type
+							{
+								type[]=
+								{
+									"SCALAR"
+								};
+							};
+							value=3;
+						};
+					};
+				};
+				nAttributes=5;
+			};
+		};
+		class Item175
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={625.99298,5,847.98901};
+			};
+			name="bwmf_placedSpectator_1";
+			isPlayable=1;
+			description="Spectator";
+			id=2919;
+			type="potato_spectate_playableSpectator";
+		};
+		class Item176
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={624.00952,5,848.00073};
+			};
+			name="bwmf_placedSpectator_2";
+			isPlayable=1;
+			description="Spectator";
+			id=2920;
+			type="potato_spectate_playableSpectator";
+		};
+		class Item177
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={621.97601,5,847.96198};
+			};
+			name="bwmf_placedSpectator_3";
+			isPlayable=1;
+			description="Spectator";
+			id=2921;
+			type="potato_spectate_playableSpectator";
+		};
+		class Item178
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={619.97424,5,847.94763};
+			};
+			name="bwmf_placedSpectator_4";
+			isPlayable=1;
+			description="Spectator";
+			id=2922;
+			type="potato_spectate_playableSpectator";
+		};
+		class Item179
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={617.99323,5,847.9826};
+			};
+			name="bwmf_placedSpectator_5";
+			isPlayable=1;
+			description="Spectator";
+			id=2923;
+			type="potato_spectate_playableSpectator";
 		};
 	};
 };


### PR DESCRIPTION
Overall should be a direct port of existing framework ACE settings to 3DEN/CBA settings.

Changed settings during the port:
- Using ACE's friendly fire fix, removing BWMF's
- Set Ace bleeding coefficient from 1.25 -> 1.5 (was 2 POTATO side, until recently https://github.com/BourbonWarfare/POTATO/pull/205/files#diff-448d9aea2eb9293dc60ac39b70b55642L43 )
- AI use POTATO defaults
- Added extra Zeus slot (a lot more co-zeused missions)
- POTATO spectators added
- By default civs speak all three languages (AR, EN, RU)
- Cleaned up unused revive 3DEN settings.

@PabstMirror can you just sanity check my medical changes please?