### PR TITLE
Standardize macro names add fins

### DIFF
--- a/CfgLoadouts.hpp
+++ b/CfgLoadouts.hpp
@@ -43,6 +43,8 @@ class CfgLoadouts {
   // Czechia: Bren 805 - M95 "Loadouts\cz_B805_m95.hpp"
   // Czechoslovakia: vz. 58 - M95 "Loadouts\cz_vz58_m95.hpp"
   // FIA: Tar-21 - Guerilla "Loadouts\fia_tar21_gur.hpp"
+  // Finland: AK103 - M05 (Snow) "Loadouts\fin_ak103_m05s.hpp"
+  // Finland: AK103 - M05 (Woodland) "Loadouts\fin_ak103_m05w.hpp"
   // German: G36 - Flecktarn Camo "Loadouts\ger_g36_fleck.hpp"
   // German: G36 - Tropentarn Camo "Loadouts\ger_g36_tropen.hpp"
   // German: G38 - Flecktarn Camo "Loadouts\ger_g38_fleck.hpp"

--- a/Loadouts/aaf_f2000_digi.hpp
+++ b/Loadouts/aaf_f2000_digi.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "hgun_Rook40_F"
 #define PISTOL_MAG "16Rnd_9x21_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -99,15 +99,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -175,8 +175,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -187,8 +187,8 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
@@ -196,14 +196,14 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_rgr"};
   headgear[] = {"H_HelmetCrew_I"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_oli"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetIA"};

--- a/Loadouts/blankForArsenal.hpp
+++ b/Loadouts/blankForArsenal.hpp
@@ -29,12 +29,12 @@
 #define PISTOL "rhsusf_weap_m1911a1"
 #define PISTOL_MAG "rhsusf_mag_7x45acp_MHP:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -61,8 +61,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -79,15 +79,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -152,8 +152,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -163,20 +163,20 @@ class Helipilot_F {// Pilot
   headgear[] = {"H_PilotHelmetHeli_B"};
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   items[] += {BASE_ENG};

--- a/Loadouts/brit_hk416_bs_apex.hpp
+++ b/Loadouts/brit_hk416_bs_apex.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "hgun_Pistol_heavy_01_F"
 #define PISTOL_MAG "11Rnd_45ACP_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -100,15 +100,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -176,8 +176,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -188,22 +188,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_khk"};
   headgear[] = {"H_HelmetCrew_B"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_khk"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetB"};

--- a/Loadouts/brit_hk416_gs_apex.hpp
+++ b/Loadouts/brit_hk416_gs_apex.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "hgun_Pistol_heavy_01_F"
 #define PISTOL_MAG "11Rnd_45ACP_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -99,15 +99,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -174,8 +174,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -186,22 +186,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_oli"};
   headgear[] = {"H_HelmetCrew_B"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_oli"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetB_TI_tna_F"};

--- a/Loadouts/brit_l85_ddpm.hpp
+++ b/Loadouts/brit_l85_ddpm.hpp
@@ -49,12 +49,12 @@
 #define PISTOL "CUP_hgun_Glock17_tan"
 #define PISTOL_MAG "CUP_17Rnd_9x19_glock17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -81,8 +81,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -102,15 +102,15 @@ class Soldier_SL_F: Soldier_TL_F {// SL
   backpack[] = {"B_Kitbag_cbr"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -186,8 +186,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -198,8 +198,8 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
@@ -209,13 +209,13 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   headgear[] = {"CUP_H_BAF_Crew_Helmet_DDPM"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
-  items[] += {BASE_MEDICAL,KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
+  items[] += {BASE_MEDICAL,SIDE_KEY};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  items[] += {RADIO_MR,KEY};
+  items[] += {RADIO_MR,SIDE_KEY};
   backpackItems[] = {"Toolkit"};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: Fic_Soldier_Carbine {
   backpack[] = {"B_Kitbag_cbr"};

--- a/Loadouts/brit_l85_mtp.hpp
+++ b/Loadouts/brit_l85_mtp.hpp
@@ -49,12 +49,12 @@
 #define PISTOL "CUP_hgun_Glock17_tan"
 #define PISTOL_MAG "CUP_17Rnd_9x19_glock17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -81,8 +81,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -102,15 +102,15 @@ class Soldier_SL_F: Soldier_TL_F {// SL
   backpack[] = {"B_Kitbag_cbr"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -184,8 +184,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -196,8 +196,8 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
@@ -207,13 +207,13 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   headgear[] = {"CUP_H_BAF_Crew_Helmet_MTP"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
-  items[] += {BASE_MEDICAL,KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
+  items[] += {BASE_MEDICAL,SIDE_KEY};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  items[] += {RADIO_MR,KEY};
+  items[] += {RADIO_MR,SIDE_KEY};
   backpackItems[] = {"Toolkit"};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: Fic_Soldier_Carbine {
   backpack[] = {"B_Kitbag_cbr"};

--- a/Loadouts/brit_l85_wdpm.hpp
+++ b/Loadouts/brit_l85_wdpm.hpp
@@ -49,12 +49,12 @@
 #define PISTOL "CUP_hgun_Glock17_tan"
 #define PISTOL_MAG "CUP_17Rnd_9x19_glock17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -81,8 +81,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -102,15 +102,15 @@ class Soldier_SL_F: Soldier_TL_F {// SL
   backpack[] = {"B_Kitbag_rgr"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -186,8 +186,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -198,8 +198,8 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
@@ -209,13 +209,13 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   headgear[] = {"CUP_H_BAF_Crew_Helmet_DPM"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
-  items[] += {BASE_MEDICAL,KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
+  items[] += {BASE_MEDICAL,SIDE_KEY};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  items[] += {RADIO_MR,KEY};
+  items[] += {RADIO_MR,SIDE_KEY};
   backpackItems[] = {"Toolkit"};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: Fic_Soldier_Carbine {
   backpack[] = {"B_Kitbag_rgr"};

--- a/Loadouts/brit_mx_bs.hpp
+++ b/Loadouts/brit_mx_bs.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "hgun_Pistol_heavy_01_F"
 #define PISTOL_MAG "11Rnd_45ACP_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -100,15 +100,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -176,8 +176,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -188,22 +188,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_khk"};
   headgear[] = {"H_HelmetCrew_B"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_khk"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetB"};

--- a/Loadouts/brit_mx_gs_apex.hpp
+++ b/Loadouts/brit_mx_gs_apex.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "hgun_Pistol_heavy_01_F"
 #define PISTOL_MAG "11Rnd_45ACP_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -99,15 +99,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -174,8 +174,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -186,22 +186,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_oli"};
   headgear[] = {"H_HelmetCrew_B"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_oli"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetB_TI_tna_F"};

--- a/Loadouts/can_m16_cpd.hpp
+++ b/Loadouts/can_m16_cpd.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "rhsusf_weap_m1911a1"
 #define PISTOL_MAG "rhsusf_mag_7x45acp_MHP:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,15 +98,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -174,8 +174,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -186,20 +186,20 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_cbr"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"MNP_Helmet_Canada_D"};

--- a/Loadouts/can_m16_cptw.hpp
+++ b/Loadouts/can_m16_cptw.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "rhsusf_weap_m1911a1"
 #define PISTOL_MAG "rhsusf_mag_7x45acp_MHP:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,15 +98,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -173,8 +173,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -185,20 +185,20 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_oli"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"MNP_Helmet_Canada_T"};

--- a/Loadouts/chi_qbz95_universal_apex.hpp
+++ b/Loadouts/chi_qbz95_universal_apex.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "rhs_weap_pya"
 #define PISTOL_MAG "rhs_mag_9x19_17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F { // rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,15 +98,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class soldier_SL_F: Soldier_TL_F { // SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F { // CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class soldier_GL_F: Soldier_TL_F {}; // GP Dude
 class Soldier_AR_F: Soldier_F {// AR
@@ -172,8 +172,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -184,20 +184,20 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   backpack[] = {"MNP_B_Carryall_PLA_Basic"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {KEY,RADIO_LR};
+  backpackItems[] += {SIDE_KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   backpack[] = {"MNP_B_Carryall_PLA_Basic"};

--- a/Loadouts/civ_gear.hpp
+++ b/Loadouts/civ_gear.hpp
@@ -1,6 +1,6 @@
 #include "undef_side_gear.hpp"  // Reset defines
 
-#define KEY "ACE_key_civ"
-#define CHEM_LIGHT "Chemlight_yellow:2"
-#define UAV_BACKPACK "C_IDAP_UAV_01_backpack_F" // Orange DLC notice
-#define UAV_TERMINAL "C_uavterminal" // test, not on wiki
+#define SIDE_KEY "ACE_SIDE_KEY_civ"
+#define SIDE_CHEM_LIGHT "Chemlight_yellow:2"
+#define SIDE_UAV_BACKPACK "C_IDAP_UAV_01_backpack_F" // Orange DLC notice
+#define SIDE_UAV_TERMINAL "C_uavterminal" // test, not on wiki

--- a/Loadouts/civ_gear.hpp
+++ b/Loadouts/civ_gear.hpp
@@ -1,6 +1,6 @@
 #include "undef_side_gear.hpp"  // Reset defines
 
-#define SIDE_KEY "ACE_SIDE_KEY_civ"
+#define SIDE_KEY "ACE_key_civ"
 #define SIDE_CHEM_LIGHT "Chemlight_yellow:2"
 #define SIDE_UAV_BACKPACK "C_IDAP_UAV_01_backpack_F" // Orange DLC notice
 #define SIDE_UAV_TERMINAL "C_uavterminal" // test, not on wiki

--- a/Loadouts/civilians.hpp
+++ b/Loadouts/civilians.hpp
@@ -12,7 +12,7 @@ class CIV_F {
     handguns[] = {};
     magazines[] = {};
     items[] = {BASE_MEDICAL};
-    linkedItems[] = {BASE_LINKED};
+    linkedItems[] = {LINKED};
     attachments[] = {};
   };
   class C_journalist_F: C_man_1 {

--- a/Loadouts/common.hpp
+++ b/Loadouts/common.hpp
@@ -8,10 +8,10 @@
 // GEAR
 #define BASE_MEDICAL "ACE_elasticBandage:4","ACE_packingBandage:2","ACE_tourniquet","ACE_morphine"
 #define MEDIC_MEDICAL "ACE_elasticBandage:25","ACE_packingBandage:15","ACE_epinephrine:10","ACE_salineIV:2","ACE_salineIV_500:4","ACE_salineIV_250:8","ACE_morphine:16","ACE_tourniquet:6"
-#define COMMON_TOOLS RADIO_SR,"ACE_MapTools","ACE_IR_Strobe_item","ACE_earplugs"
-#define COMMON_LEADER_TOOLS "ACE_microDAGR","ACE_Flashlight_KSF1"
-#define COMMON_LINKED "ItemMap","ItemCompass","ItemWatch"
-#define COMMON_LEADER_LINKED "ItemGPS"
+#define BASE_TOOLS RADIO_SR,"ACE_MapTools","ACE_IR_Strobe_item","ACE_earplugs"
+#define BASE_LEADER_TOOLS "ACE_microDAGR","ACE_Flashlight_KSF1"
+#define BASE_LINKED "ItemMap","ItemCompass","ItemWatch"
+#define BASE_LEADER_LINKED "ItemGPS"
 #define BASE_FRAG "HandGrenade:2"
 #define BASE_SMOKES "SmokeShell:2"
 #define BASE_GRENADES BASE_FRAG,BASE_SMOKES
@@ -22,7 +22,7 @@
 #define BASE_EXP "DemoCharge_Remote_Mag:3","SatchelCharge_Remote_Mag:2"
 #define BASE_MINE "ATMine_Range_Mag:2","APERSBoundingMine_Range_Mag:2","APERSMine_Range_Mag:2"
 #define BINOS "Binocular"
-#define RANGE_FINDER "ACE_Vector"
+#define RANGE_FINDER "ACE_VectorDay"
 
 // OPTIX
 #define WARSAW_OPTICS "rhs_acc_1p63", "rhs_acc_ekp1", "rhs_acc_ekp8_02", "rhs_acc_pkas" // note RHS and CUP mount optics differently, not cross compatible

--- a/Loadouts/csat_qbz95_ghex_apex.hpp
+++ b/Loadouts/csat_qbz95_ghex_apex.hpp
@@ -47,12 +47,12 @@
 #define PISTOL "hgun_Rook40_F"
 #define PISTOL_MAG "16Rnd_9x21_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -79,8 +79,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,15 +98,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -173,8 +173,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -185,22 +185,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_oli"};
   headgear[] = {"H_HelmetCrew_O_ghex_F"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_ghex_F"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetO_ghex_F"};

--- a/Loadouts/csat_qbz95_hex_apex.hpp
+++ b/Loadouts/csat_qbz95_hex_apex.hpp
@@ -47,12 +47,12 @@
 #define PISTOL "hgun_Rook40_F"
 #define PISTOL_MAG "16Rnd_9x21_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -79,8 +79,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,7 +98,7 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
@@ -106,8 +106,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -173,8 +173,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -185,22 +185,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_khk"};
   headgear[] = {"H_HelmetCrew_O"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_ocamo"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetO_ocamo"};

--- a/Loadouts/csat_qbz95_uhex_apex.hpp
+++ b/Loadouts/csat_qbz95_uhex_apex.hpp
@@ -47,12 +47,12 @@
 #define PISTOL "hgun_Rook40_F"
 #define PISTOL_MAG "16Rnd_9x21_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -79,8 +79,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,15 +98,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -173,8 +173,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -185,22 +185,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_blk"};
   headgear[] = {"H_HelmetCrew_O"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_oucamo"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetO_oucamo"};

--- a/Loadouts/csat_sama_hex.hpp
+++ b/Loadouts/csat_sama_hex.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "hgun_Rook40_F"
 #define PISTOL_MAG "16Rnd_9x21_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -99,7 +99,7 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
@@ -107,8 +107,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -175,8 +175,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -187,22 +187,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_khk"};
   headgear[] = {"H_HelmetCrew_O"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_ocamo"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetO_ocamo"};

--- a/Loadouts/csat_sama_uhex.hpp
+++ b/Loadouts/csat_sama_uhex.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "hgun_Rook40_F"
 #define PISTOL_MAG "16Rnd_9x21_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -99,15 +99,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -174,8 +174,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -186,22 +186,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_TacVest_blk"};
   headgear[] = {"H_HelmetCrew_O"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_oucamo"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetO_oucamo"};

--- a/Loadouts/cz_B805_m95.hpp
+++ b/Loadouts/cz_B805_m95.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "CUP_hgun_Duty"
 #define PISTOL_MAG "16Rnd_9x21_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,15 +98,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -175,8 +175,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -187,20 +187,20 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_oli"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"MNP_Helmet_CZ"};

--- a/Loadouts/cz_vz58_m95.hpp
+++ b/Loadouts/cz_vz58_m95.hpp
@@ -49,12 +49,12 @@
 #define PISTOL "CUP_hgun_Duty"
 #define PISTOL_MAG "16Rnd_9x21_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -81,8 +81,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -99,15 +99,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -177,8 +177,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -189,20 +189,20 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_oli"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"MNP_Helmet_CZ"};

--- a/Loadouts/east_gear.hpp
+++ b/Loadouts/east_gear.hpp
@@ -1,6 +1,6 @@
 #include "undef_side_gear.hpp"  // Reset defines
 
-#define SIDE_KEY "ACE_SIDE_KEY_east"
+#define SIDE_KEY "ACE_key_east"
 #define SIDE_CHEM_LIGHT "Chemlight_red:2"
 #define SIDE_UAV_BACKPACK "O_UAV_01_backpack_F"
 #define SIDE_UAV_TERMINAL "O_uavterminal"

--- a/Loadouts/east_gear.hpp
+++ b/Loadouts/east_gear.hpp
@@ -1,6 +1,6 @@
 #include "undef_side_gear.hpp"  // Reset defines
 
-#define KEY "ACE_key_east"
-#define CHEM_LIGHT "Chemlight_red:2"
-#define UAV_BACKPACK "O_UAV_01_backpack_F"
-#define UAV_TERMINAL "O_uavterminal"
+#define SIDE_KEY "ACE_SIDE_KEY_east"
+#define SIDE_CHEM_LIGHT "Chemlight_red:2"
+#define SIDE_UAV_BACKPACK "O_UAV_01_backpack_F"
+#define SIDE_UAV_TERMINAL "O_uavterminal"

--- a/Loadouts/fia_tar21_gur.hpp
+++ b/Loadouts/fia_tar21_gur.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "hgun_Rook40_F"
 #define PISTOL_MAG "16Rnd_9x21_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -99,7 +99,7 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
@@ -107,8 +107,8 @@ class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -176,8 +176,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -188,8 +188,8 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
@@ -197,14 +197,14 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_rgr"};
   headgear[] = {"H_HelmetCrew_I"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_oli"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetB_grass"};

--- a/Loadouts/fin_ak103_m05s.hpp
+++ b/Loadouts/fin_ak103_m05s.hpp
@@ -1,0 +1,217 @@
+// Author: Mozaik
+// Description: Finland: AK103 - M05 (Snow)
+
+#include "undef.hpp" // Reset defines
+
+// Rifle
+#define RIFLE "rhs_weap_ak103"
+#define RIFLE_MAG "30Rnd_762x39_Mag_F:8","30Rnd_762x39_Mag_Tracer_Green_F:2"
+#define RIFLE_ATTACHMENTS "rhs_acc_dtkakm","rhs_acc_perst1ik"
+#define ALT_OPTICS WARSAW_OPTICS
+// GL Rifle
+#define GLRIFLE "rhs_weap_ak103_gp25"
+#define GLRIFLE_MAG RIFLE_MAG
+#define GLRIFLE_MAG_SMOKE "1Rnd_Smoke_Grenade_shell:2","1Rnd_SmokeRed_Grenade_shell:2"
+#define GLRIFLE_MAG_HE "1Rnd_HE_Grenade_shell:5"
+// Carbine
+#define CARBINE "rhs_weap_ak104"
+#define CARBINE_MAG RIFLE_MAG
+// AR
+#define AR "rhs_weap_pkm" // FIXME (RPK?)
+#define AR_MAG "rhs_100Rnd_762x54mmR_green:4"
+// AT
+#define AT "rhs_weap_m72a7"
+// MMG
+#define MMG "rhs_weap_pkm"
+#define MMG_MAG "rhs_100Rnd_762x54mmR_green:5"
+// MAT
+#define MAT "rhs_weap_maaws"
+#define MAT_MAG "rhs_mag_maaws_HEAT:3","rhs_mag_maaws_HEDP:1"
+#define MAT_MAG2 "rhs_mag_maaws_HEAT:2","rhs_mag_maaws_HEDP:1"
+#define MAT_OPTIC "rhs_optic_maaws"
+// SAM
+#define SAM "rhs_weap_fim92"
+#define SAM_MAG "rhs_fim92_mag:3"
+#define SAM_MAG2 "rhs_fim92_mag:2"
+// Sniper Rifle
+#define SNIPER "rhs_weap_svds_npz"
+#define SNIPER_MAG "rhs_10Rnd_762x54mmR_7N1:20"
+#define SNIPER_ATTACHMENTS "optic_LRPS"
+// Spotter Rifle
+#define SPOTTER "rhs_weap_ak103"
+#define SPOTTER_MAG RIFLE_MAG
+#define SPOTTER_ATTACHMENTS "rhs_acc_1p78","rhs_acc_perst1ik","rhs_acc_dtk3"
+// SMG
+#define SMG "rhs_weap_aks74u"
+#define SMG_MAG "rhs_30Rnd_545x39_AK:6"
+// Pistol
+#define PISTOL "rhs_weap_makarov_pmm"
+#define PISTOL_MAG "rhs_mag_9x18_12_57N181S:3"
+// Grenades
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
+// Gear
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
+
+class Car {
+  TransportWeapons[] = {AT};
+  TransportMagazines[] = {RIFLE_MAG,RIFLE_MAG,CARBINE_MAG,AR_MAG,AR_MAG,GLRIFLE_MAG_HE};
+  TransportItems[] = {BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL};
+};
+class Tank {
+  TransportWeapons[] = {AT};
+  TransportMagazines[] = {RIFLE_MAG,RIFLE_MAG,CARBINE_MAG,AR_MAG,AR_MAG,GLRIFLE_MAG_HE};
+  TransportItems[] = {BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL};
+};
+class Helicopter {
+  TransportMagazines[] = {RIFLE_MAG,RIFLE_MAG,CARBINE_MAG,AR_MAG,AR_MAG,GLRIFLE_MAG_HE};
+  TransportItems[] = {BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL};
+};
+class Plane {};
+class Ship_F {};
+
+class Soldier_F {// rifleman
+  uniform[] = {"MNP_CombatUniform_Finarctic_A"};
+  vest[] = {"MNP_Vest_USMC_Xtreme_B"};
+  headgear[] = {"MNP_Helmet_FIN_A"};
+  backpack[] = {"MNP_B_WB_KB"};
+  backpackItems[] = {BASE_MEDICAL};
+  weapons[] = {RIFLE};
+  magazines[] = {RIFLE_MAG,BASE_GRENADES};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
+  attachments[] = {RIFLE_ATTACHMENTS};
+  opticChoices[] = {ALT_OPTICS};
+};
+class Fic_Soldier_Carbine: Soldier_F {// carbine-man
+  weapons[] = {CARBINE};
+  magazines[] = {CARBINE_MAG,BASE_GRENADES};
+};
+class Soldier_TL_F: Soldier_F {// FTL
+  headgear[] = {"MNP_Boonie_AFIN"};
+  weapons[] = {GLRIFLE};
+  magazines[] = {GLRIFLE_MAG,GLRIFLE_MAG_HE,GLRIFLE_MAG_SMOKE,LEADER_GRENADES};
+  items[] += {LEADER_TOOLS};
+  linkedItems[] += {LEADER_LINKED,BINOS};
+};
+class Soldier_SL_F: Soldier_TL_F {// SL
+  handguns[] = {PISTOL};
+  magazines[] += {PISTOL_MAG};
+  linkedItems[] += {LINKED,LEADER_LINKED,RANGE_FINDER};
+  items[] += {RADIO_MR};
+};
+class officer_F: Soldier_SL_F {// CO and DC
+  items[] += {RADIO_LR};
+};
+class soldier_UAV_F: Soldier_F {
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
+};
+class Soldier_AR_F: Soldier_F {// AR
+  weapons[] = {AR};
+  magazines[] = {AR_MAG,PISTOL_MAG,BASE_GRENADES};
+  handguns[] = {PISTOL};
+};
+class Soldier_AAR_F: Soldier_F {// AAR
+  backpackItems[] += {AR_MAG};
+  linkeditems[] += {BINOS};
+};
+class Soldier_LAT_F: Fic_Soldier_Carbine {// RAT
+  launchers[] = {AT};
+};
+class medic_F: Fic_Soldier_Carbine {// Medic
+  magazines[] = {CARBINE_MAG,MEDIC_GRENADES};
+  backpackItems[] = {MEDIC_MEDICAL};
+};
+class Fic_Spotter: Soldier_F {
+  linkedItems[] += {RANGE_FINDER};
+};
+class support_MG_F: Soldier_AR_F {// MMG
+  weapons[] = {MMG};
+  magazines[] = {MMG_MAG,PISTOL_MAG,BASE_GRENADES};
+  attachments[] = {};
+};
+class Soldier_A_F: Fic_Spotter {// MMG Spotter/Ammo Bearer
+  backpackItems[] += {MMG_MAG};
+};
+class soldier_AT_F: Fic_Soldier_Carbine {// MAT Gunner
+  backpack[] = {"B_Carryall_mcamo"}; // FIXME
+  backpackItems[] = {};
+  magazines[] += {MAT_MAG};
+  items[] += {BASE_MEDICAL};
+  launchers[] = {MAT};
+  secondaryAttachments[] = {MAT_OPTIC};
+};
+class Soldier_AAT_F: Fic_Spotter {// MAT Spotter/Ammo Bearer
+  backpack[] = {"B_Carryall_mcamo"}; // FIXME
+  backpackItems[] = {};
+  magazines[] += {MAT_MAG};
+  items[] += {BASE_MEDICAL};
+};
+class soldier_AA_F: Fic_Soldier_Carbine {// SAM Gunner
+  SAM_GEAR("MNP_B_WD_CA", SAM_MAG)
+  launchers[] = {SAM};
+};
+class Soldier_AAA_F: Fic_Spotter {// SAM Spotter/Ammo Bearer
+  SAM_GEAR("MNP_B_WD_CA", SAM_MAG)
+};
+class support_Mort_F: Fic_Soldier_Carbine {// Mortar Gunner
+  MORTAR_GEAR("I_Mortar_01_weapon_F")
+};
+class support_AMort_F: Fic_Spotter {// Assistant Mortar
+  MORTAR_GEAR("I_Mortar_01_support_F")
+};
+class spotter_F: Fic_Spotter {// Spotter
+  headgear[] = {"MNP_Boonie_FIN","rhs_beanie_green"};
+  weapons[] = {SPOTTER};
+  magazines[] = {SPOTTER_MAG,BASE_GRENADES};
+  items[] += {RADIO_MR,"ACE_ATragMX","ACE_Kestrel4500","ACE_RangeCard"};
+  linkedItems[] += {LEADER_LINKED};
+  attachments[] = {SPOTTER_ATTACHMENTS};
+};
+class sniper_F: spotter_F {// Sniper
+  headgear[] = {"MNP_Boonie_FIN"};
+  weapons[] = {SNIPER};
+  magazines[] = {SNIPER_MAG,BASE_GRENADES};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED,LEADER_LINKED};
+  attachments[] = {SNIPER_ATTACHMENTS};
+};
+class Helipilot_F {// Pilot
+  uniform[] = {"rhs_uniform_df15"};
+  vest[] = {"V_TacVest_blk"};
+  headgear[] = {"rhs_zsh7a_mike"};
+  backpack[] = {"B_AssaultPack_rgr"};
+  weapons[] = {SMG};
+  magazines[] = {SMG_MAG,CREW_GRENADES};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  backpackItems[] += {SIDE_KEY_IND,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
+};
+class helicrew_F: Helipilot_F {}; // Pilot
+class crew_F: Fic_Soldier_Carbine {// Crew
+  magazines[] = {CARBINE_MAG,CREW_GRENADES};
+  backpackItems[] += {SIDE_KEY_IND,RADIO_LR};
+  linkedItems[] += {LEADER_LINKED,BINOS};
+  items[] += {BASE_MEDICAL};
+};
+class Soldier_repair_F: crew_F {// Repair Specialist
+  backpack[] = {"MNP_B_WD_CA"};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY_IND};
+  linkedItems[] = {LINKED,LEADER_LINKED};
+};
+class Fic_Eng: soldier_repair_F {
+  uniform[] = {"MNP_CombatUniform_ASA_GC","MNP_CombatUniform_ASA_GC3","MNP_CombatUniform_ASA_GC2"};
+  items[] += {BASE_ENG};
+  backpackItems[] = {};
+};
+class soldier_exp_F: Fic_Eng {// Explosive Specialist
+  magazines[] += {BASE_EXP};
+  backpackItems[] = {"Toolkit"};
+};
+class engineer_F: Fic_Eng {// Mine Specialist
+  magazines[] += {BASE_MINE};
+};
+class fallback: Soldier_F {}; // This means any faction member who doesn't match something will use this loadout

--- a/Loadouts/fin_ak103_m05s.hpp
+++ b/Loadouts/fin_ak103_m05s.hpp
@@ -6,7 +6,7 @@
 // Rifle
 #define RIFLE "rhs_weap_ak103"
 #define RIFLE_MAG "30Rnd_762x39_Mag_F:8","30Rnd_762x39_Mag_Tracer_Green_F:2"
-#define RIFLE_ATTACHMENTS "rhs_acc_dtkakm","rhs_acc_perst1ik"
+#define RIFLE_ATTACHMENTS "rhs_acc_dtk","rhs_acc_perst1ik"
 #define ALT_OPTICS WARSAW_OPTICS
 // GL Rifle
 #define GLRIFLE "rhs_weap_ak103_gp25"
@@ -17,8 +17,9 @@
 #define CARBINE "rhs_weap_ak104"
 #define CARBINE_MAG RIFLE_MAG
 // AR
-#define AR "rhs_weap_pkm" // FIXME (RPK?)
-#define AR_MAG "rhs_100Rnd_762x54mmR_green:4"
+#define AR "potato_arifle_RPK"
+#define AR_MAG "potato_75Rnd_762x39mm_tracer:6"
+#define AR_ATTACHMENTS "CUP_optic_Kobra"
 // AT
 #define AT "rhs_weap_m72a7"
 // MMG
@@ -73,10 +74,10 @@ class Plane {};
 class Ship_F {};
 
 class Soldier_F {// rifleman
-  uniform[] = {"MNP_CombatUniform_Finarctic_A"};
-  vest[] = {"MNP_Vest_USMC_Xtreme_B"};
+  uniform[] = {"MNP_CombatUniform_Finarctic_A","MNP_CombatUniform_Finarctic_B"};
+  vest[] = {"CUP_V_PMC_CIRAS_Winter_Empty","CUP_V_PMC_CIRAS_Winter_Patrol"};
   headgear[] = {"MNP_Helmet_FIN_A"};
-  backpack[] = {"MNP_B_WB_KB"};
+  backpack[] = {"MNP_B_WB_AP"};
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
@@ -90,19 +91,20 @@ class Fic_Soldier_Carbine: Soldier_F {// carbine-man
   magazines[] = {CARBINE_MAG,BASE_GRENADES};
 };
 class Soldier_TL_F: Soldier_F {// FTL
-  headgear[] = {"MNP_Boonie_AFIN"};
   weapons[] = {GLRIFLE};
   magazines[] = {GLRIFLE_MAG,GLRIFLE_MAG_HE,GLRIFLE_MAG_SMOKE,LEADER_GRENADES};
   items[] += {LEADER_TOOLS};
   linkedItems[] += {LEADER_LINKED,BINOS};
 };
 class Soldier_SL_F: Soldier_TL_F {// SL
+  vest[] = {"CUP_V_PMC_CIRAS_Winter_TL"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
   linkedItems[] += {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
+  backpack[] = {"MNP_B_WB_KB"};
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
@@ -111,6 +113,8 @@ class soldier_UAV_F: Soldier_F {
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
+  attachments[] = {};
+  opticChoices[] = {AR_ATTACHMENTS};
   magazines[] = {AR_MAG,PISTOL_MAG,BASE_GRENADES};
   handguns[] = {PISTOL};
 };
@@ -134,10 +138,11 @@ class support_MG_F: Soldier_AR_F {// MMG
   attachments[] = {};
 };
 class Soldier_A_F: Fic_Spotter {// MMG Spotter/Ammo Bearer
+  backpack[] = {"MNP_B_RUW_CA"};
   backpackItems[] += {MMG_MAG};
 };
 class soldier_AT_F: Fic_Soldier_Carbine {// MAT Gunner
-  backpack[] = {"B_Carryall_mcamo"}; // FIXME
+  backpack[] = {"MNP_B_RUW_CA"};
   backpackItems[] = {};
   magazines[] += {MAT_MAG};
   items[] += {BASE_MEDICAL};
@@ -145,17 +150,17 @@ class soldier_AT_F: Fic_Soldier_Carbine {// MAT Gunner
   secondaryAttachments[] = {MAT_OPTIC};
 };
 class Soldier_AAT_F: Fic_Spotter {// MAT Spotter/Ammo Bearer
-  backpack[] = {"B_Carryall_mcamo"}; // FIXME
+  backpack[] = {"MNP_B_RUW_CA"};
   backpackItems[] = {};
-  magazines[] += {MAT_MAG};
+  magazines[] += {MAT_MAG2};
   items[] += {BASE_MEDICAL};
 };
 class soldier_AA_F: Fic_Soldier_Carbine {// SAM Gunner
-  SAM_GEAR("MNP_B_WD_CA", SAM_MAG)
+  SAM_GEAR("MNP_B_RUW_CA", SAM_MAG)
   launchers[] = {SAM};
 };
 class Soldier_AAA_F: Fic_Spotter {// SAM Spotter/Ammo Bearer
-  SAM_GEAR("MNP_B_WD_CA", SAM_MAG)
+  SAM_GEAR("MNP_B_RUW_CA", SAM_MAG2)
 };
 class support_Mort_F: Fic_Soldier_Carbine {// Mortar Gunner
   MORTAR_GEAR("I_Mortar_01_weapon_F")
@@ -164,7 +169,7 @@ class support_AMort_F: Fic_Spotter {// Assistant Mortar
   MORTAR_GEAR("I_Mortar_01_support_F")
 };
 class spotter_F: Fic_Spotter {// Spotter
-  headgear[] = {"MNP_Boonie_FIN","rhs_beanie_green"};
+  headgear[] = {"MNP_Boonie_AFIN"};
   weapons[] = {SPOTTER};
   magazines[] = {SPOTTER_MAG,BASE_GRENADES};
   items[] += {RADIO_MR,"ACE_ATragMX","ACE_Kestrel4500","ACE_RangeCard"};
@@ -172,7 +177,7 @@ class spotter_F: Fic_Spotter {// Spotter
   attachments[] = {SPOTTER_ATTACHMENTS};
 };
 class sniper_F: spotter_F {// Sniper
-  headgear[] = {"MNP_Boonie_FIN"};
+  headgear[] = {"MNP_Boonie_AFIN"};
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
   items[] = {TOOLS,"ACE_RangeCard"};
@@ -187,23 +192,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
-  backpackItems[] += {SIDE_KEY_IND,RADIO_LR};
+  backpackItems[] += {SIDE_KEY,RADIO_LR};
   linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {SIDE_KEY_IND,RADIO_LR};
+  backpackItems[] += {SIDE_KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class Soldier_repair_F: crew_F {// Repair Specialist
-  backpack[] = {"MNP_B_WD_CA"};
-  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY_IND};
+  backpack[] = {"MNP_B_RUW_CA"};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
   linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_Eng: soldier_repair_F {
-  uniform[] = {"MNP_CombatUniform_ASA_GC","MNP_CombatUniform_ASA_GC3","MNP_CombatUniform_ASA_GC2"};
   items[] += {BASE_ENG};
   backpackItems[] = {};
 };

--- a/Loadouts/fin_ak103_m05w.hpp
+++ b/Loadouts/fin_ak103_m05w.hpp
@@ -1,0 +1,218 @@
+// Author: Mozaik
+// Description: Finland: AK103 - M05 (Woodland)
+
+#include "undef.hpp" // Reset defines
+
+// Rifle
+#define RIFLE "rhs_weap_ak103"
+#define RIFLE_MAG "30Rnd_762x39_Mag_F:8","30Rnd_762x39_Mag_Tracer_Green_F:2"
+#define RIFLE_ATTACHMENTS "rhs_acc_dtkakm","rhs_acc_perst1ik"
+#define ALT_OPTICS WARSAW_OPTICS
+// GL Rifle
+#define GLRIFLE "rhs_weap_ak103_gp25"
+#define GLRIFLE_MAG RIFLE_MAG
+#define GLRIFLE_MAG_SMOKE "1Rnd_Smoke_Grenade_shell:2","1Rnd_SmokeRed_Grenade_shell:2"
+#define GLRIFLE_MAG_HE "1Rnd_HE_Grenade_shell:5"
+// Carbine
+#define CARBINE "rhs_weap_ak104"
+#define CARBINE_MAG RIFLE_MAG
+// AR
+#define AR "rhs_weap_pkm" // FIXME (RPK?)
+#define AR_MAG "rhs_100Rnd_762x54mmR_green:4"
+// AT
+#define AT "rhs_weap_m72a7"
+// MMG
+#define MMG "rhs_weap_pkm"
+#define MMG_MAG "rhs_100Rnd_762x54mmR_green:5"
+// MAT
+#define MAT "rhs_weap_maaws"
+#define MAT_MAG "rhs_mag_maaws_HEAT:3","rhs_mag_maaws_HEDP:1"
+#define MAT_MAG2 "rhs_mag_maaws_HEAT:2","rhs_mag_maaws_HEDP:1"
+#define MAT_OPTIC "rhs_optic_maaws"
+// SAM
+#define SAM "rhs_weap_fim92"
+#define SAM_MAG "rhs_fim92_mag:3"
+#define SAM_MAG2 "rhs_fim92_mag:2"
+// Sniper Rifle
+#define SNIPER "rhs_weap_svds_npz"
+#define SNIPER_MAG "rhs_10Rnd_762x54mmR_7N1:20"
+#define SNIPER_ATTACHMENTS "optic_LRPS"
+// Spotter Rifle
+#define SPOTTER "rhs_weap_ak103"
+#define SPOTTER_MAG RIFLE_MAG
+#define SPOTTER_ATTACHMENTS "rhs_acc_1p78","rhs_acc_perst1ik","rhs_acc_dtk3"
+// SMG
+#define SMG "rhs_weap_aks74u"
+#define SMG_MAG "rhs_30Rnd_545x39_AK:6"
+// Pistol
+#define PISTOL "rhs_weap_makarov_pmm"
+#define PISTOL_MAG "rhs_mag_9x18_12_57N181S:3"
+// Grenades
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
+// Gear
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
+
+class Car {
+  TransportWeapons[] = {AT};
+  TransportMagazines[] = {RIFLE_MAG,RIFLE_MAG,CARBINE_MAG,AR_MAG,AR_MAG,GLRIFLE_MAG_HE};
+  TransportItems[] = {BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL};
+};
+class Tank {
+  TransportWeapons[] = {AT};
+  TransportMagazines[] = {RIFLE_MAG,RIFLE_MAG,CARBINE_MAG,AR_MAG,AR_MAG,GLRIFLE_MAG_HE};
+  TransportItems[] = {BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL};
+};
+class Helicopter {
+  TransportMagazines[] = {RIFLE_MAG,RIFLE_MAG,CARBINE_MAG,AR_MAG,AR_MAG,GLRIFLE_MAG_HE};
+  TransportItems[] = {BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL};
+};
+class Plane {};
+class Ship_F {};
+
+class Soldier_F {// rifleman
+  uniform[] = {"MNP_CombatUniform_Fin_A"};
+  vest[] = {"MNP_Vest_FIN_2","MNP_Vest_FIN_2"};
+  headgear[] = {"MNP_Helmet_FIN_T"};
+  backpack[] = {}; //FIXME
+  backpackItems[] = {BASE_MEDICAL};
+  weapons[] = {RIFLE};
+  magazines[] = {RIFLE_MAG,BASE_GRENADES};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
+  attachments[] = {RIFLE_ATTACHMENTS};
+  opticChoices[] = {ALT_OPTICS};
+};
+class Fic_Soldier_Carbine: Soldier_F {// carbine-man
+  weapons[] = {CARBINE};
+  magazines[] = {CARBINE_MAG,BASE_GRENADES};
+};
+class Soldier_TL_F: Soldier_F {// FTL
+  headgear[] = {"MNP_Boonie_FIN"};
+  weapons[] = {GLRIFLE};
+  magazines[] = {GLRIFLE_MAG,GLRIFLE_MAG_HE,GLRIFLE_MAG_SMOKE,LEADER_GRENADES};
+  items[] += {LEADER_TOOLS};
+  linkedItems[] += {LEADER_LINKED,BINOS};
+};
+class Soldier_SL_F: Soldier_TL_F {// SL
+  handguns[] = {PISTOL};
+  magazines[] += {PISTOL_MAG};
+  linkedItems[] += {LINKED,LEADER_LINKED,RANGE_FINDER};
+  items[] += {RADIO_MR};
+};
+class officer_F: Soldier_SL_F {// CO and DC
+  items[] += {RADIO_LR};
+};
+class soldier_UAV_F: Soldier_F {
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
+};
+class Soldier_AR_F: Soldier_F {// AR
+  weapons[] = {AR};
+  magazines[] = {AR_MAG,PISTOL_MAG,BASE_GRENADES};
+  handguns[] = {PISTOL};
+};
+class Soldier_AAR_F: Soldier_F {// AAR
+  backpackItems[] += {AR_MAG};
+  linkeditems[] += {BINOS};
+};
+class Soldier_LAT_F: Fic_Soldier_Carbine {// RAT
+  backpackItems[] += {AT};
+  launchers[] = {AT};
+};
+class medic_F: Fic_Soldier_Carbine {// Medic
+  magazines[] = {CARBINE_MAG,MEDIC_GRENADES};
+  backpackItems[] = {MEDIC_MEDICAL};
+};
+class Fic_Spotter: Soldier_F {
+  linkedItems[] += {RANGE_FINDER};
+};
+class support_MG_F: Soldier_AR_F {// MMG
+  weapons[] = {MMG};
+  magazines[] = {MMG_MAG,PISTOL_MAG,BASE_GRENADES};
+  attachments[] = {};
+};
+class Soldier_A_F: Fic_Spotter {// MMG Spotter/Ammo Bearer
+  backpackItems[] += {MMG_MAG};
+};
+class soldier_AT_F: Fic_Soldier_Carbine {// MAT Gunner
+  backpack[] = {"B_Carryall_mcamo"}; // FIXME
+  backpackItems[] = {};
+  magazines[] += {MAT_MAG};
+  items[] += {BASE_MEDICAL};
+  launchers[] = {MAT};
+  secondaryAttachments[] = {MAT_OPTIC};
+};
+class Soldier_AAT_F: Fic_Spotter {// MAT Spotter/Ammo Bearer
+  backpack[] = {"B_Carryall_mcamo"}; // FIXME
+  backpackItems[] = {};
+  magazines[] += {MAT_MAG};
+  items[] += {BASE_MEDICAL};
+};
+class soldier_AA_F: Fic_Soldier_Carbine {// SAM Gunner
+  SAM_GEAR("MNP_B_WD_CA", SAM_MAG)
+  launchers[] = {SAM};
+};
+class Soldier_AAA_F: Fic_Spotter {// SAM Spotter/Ammo Bearer
+  SAM_GEAR("MNP_B_WD_CA", SAM_MAG)
+};
+class support_Mort_F: Fic_Soldier_Carbine {// Mortar Gunner
+  MORTAR_GEAR("I_Mortar_01_weapon_F")
+};
+class support_AMort_F: Fic_Spotter {// Assistant Mortar
+  MORTAR_GEAR("I_Mortar_01_support_F")
+};
+class spotter_F: Fic_Spotter {// Spotter
+  headgear[] = {"MNP_Boonie_FIN","rhs_beanie_green"};
+  weapons[] = {SPOTTER};
+  magazines[] = {SPOTTER_MAG,BASE_GRENADES};
+  items[] += {RADIO_MR,"ACE_ATragMX","ACE_Kestrel4500","ACE_RangeCard"};
+  linkedItems[] += {LEADER_LINKED};
+  attachments[] = {SPOTTER_ATTACHMENTS};
+};
+class sniper_F: spotter_F {// Sniper
+  headgear[] = {"MNP_Boonie_FIN"};
+  weapons[] = {SNIPER};
+  magazines[] = {SNIPER_MAG,BASE_GRENADES};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED,LEADER_LINKED};
+  attachments[] = {SNIPER_ATTACHMENTS};
+};
+class Helipilot_F {// Pilot
+  uniform[] = {"rhs_uniform_df15"};
+  vest[] = {"V_TacVest_blk"};
+  headgear[] = {"rhs_zsh7a_mike"};
+  backpack[] = {"B_AssaultPack_rgr"};
+  weapons[] = {SMG};
+  magazines[] = {SMG_MAG,CREW_GRENADES};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  backpackItems[] += {SIDE_KEY_IND,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
+};
+class helicrew_F: Helipilot_F {}; // Pilot
+class crew_F: Fic_Soldier_Carbine {// Crew
+  magazines[] = {CARBINE_MAG,CREW_GRENADES};
+  backpackItems[] += {SIDE_KEY_IND,RADIO_LR};
+  linkedItems[] += {LEADER_LINKED,BINOS};
+  items[] += {BASE_MEDICAL};
+};
+class Soldier_repair_F: crew_F {// Repair Specialist
+  backpack[] = {"MNP_B_WD_CA"};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY_IND};
+  linkedItems[] = {LINKED,LEADER_LINKED};
+};
+class Fic_Eng: soldier_repair_F {
+  uniform[] = {"MNP_CombatUniform_ASA_GC", "MNP_CombatUniform_ASA_GC3","MNP_CombatUniform_ASA_GC2"};
+  items[] += {BASE_ENG};
+  backpackItems[] = {};
+};
+class soldier_exp_F: Fic_Eng {// Explosive Specialist
+  magazines[] += {BASE_EXP};
+  backpackItems[] = {"Toolkit"};
+};
+class engineer_F: Fic_Eng {// Mine Specialist
+  magazines[] += {BASE_MINE};
+};
+class fallback: Soldier_F {}; // This means any faction member who doesn't match something will use this loadout

--- a/Loadouts/fin_ak103_m05w.hpp
+++ b/Loadouts/fin_ak103_m05w.hpp
@@ -6,7 +6,7 @@
 // Rifle
 #define RIFLE "rhs_weap_ak103"
 #define RIFLE_MAG "30Rnd_762x39_Mag_F:8","30Rnd_762x39_Mag_Tracer_Green_F:2"
-#define RIFLE_ATTACHMENTS "rhs_acc_dtkakm","rhs_acc_perst1ik"
+#define RIFLE_ATTACHMENTS "rhs_acc_dtk","rhs_acc_perst1ik"
 #define ALT_OPTICS WARSAW_OPTICS
 // GL Rifle
 #define GLRIFLE "rhs_weap_ak103_gp25"
@@ -17,8 +17,9 @@
 #define CARBINE "rhs_weap_ak104"
 #define CARBINE_MAG RIFLE_MAG
 // AR
-#define AR "rhs_weap_pkm" // FIXME (RPK?)
-#define AR_MAG "rhs_100Rnd_762x54mmR_green:4"
+#define AR "potato_arifle_RPK"
+#define AR_MAG "potato_75Rnd_762x39mm_tracer:6"
+#define AR_ATTACHMENTS "CUP_optic_Kobra"
 // AT
 #define AT "rhs_weap_m72a7"
 // MMG
@@ -73,10 +74,10 @@ class Plane {};
 class Ship_F {};
 
 class Soldier_F {// rifleman
-  uniform[] = {"MNP_CombatUniform_Fin_A"};
+  uniform[] = {"MNP_CombatUniform_Fin_A","MNP_CombatUniform_Fin_B"};
   vest[] = {"MNP_Vest_FIN_2","MNP_Vest_FIN_2"};
   headgear[] = {"MNP_Helmet_FIN_T"};
-  backpack[] = {}; //FIXME
+  backpack[] = {"B_AssaultPack_rgr"};
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
@@ -90,7 +91,6 @@ class Fic_Soldier_Carbine: Soldier_F {// carbine-man
   magazines[] = {CARBINE_MAG,BASE_GRENADES};
 };
 class Soldier_TL_F: Soldier_F {// FTL
-  headgear[] = {"MNP_Boonie_FIN"};
   weapons[] = {GLRIFLE};
   magazines[] = {GLRIFLE_MAG,GLRIFLE_MAG_HE,GLRIFLE_MAG_SMOKE,LEADER_GRENADES};
   items[] += {LEADER_TOOLS};
@@ -103,6 +103,7 @@ class Soldier_SL_F: Soldier_TL_F {// SL
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
+  backpack[] = {"B_Kitbag_rgr"};
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
@@ -111,6 +112,8 @@ class soldier_UAV_F: Soldier_F {
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
+  attachments[] = {};
+  opticChoices[] = {AR_ATTACHMENTS};
   magazines[] = {AR_MAG,PISTOL_MAG,BASE_GRENADES};
   handguns[] = {PISTOL};
 };
@@ -135,10 +138,11 @@ class support_MG_F: Soldier_AR_F {// MMG
   attachments[] = {};
 };
 class Soldier_A_F: Fic_Spotter {// MMG Spotter/Ammo Bearer
+  backpack[] = {"B_Carryall_oli"};
   backpackItems[] += {MMG_MAG};
 };
 class soldier_AT_F: Fic_Soldier_Carbine {// MAT Gunner
-  backpack[] = {"B_Carryall_mcamo"}; // FIXME
+  backpack[] = {"B_Carryall_oli"};
   backpackItems[] = {};
   magazines[] += {MAT_MAG};
   items[] += {BASE_MEDICAL};
@@ -146,17 +150,17 @@ class soldier_AT_F: Fic_Soldier_Carbine {// MAT Gunner
   secondaryAttachments[] = {MAT_OPTIC};
 };
 class Soldier_AAT_F: Fic_Spotter {// MAT Spotter/Ammo Bearer
-  backpack[] = {"B_Carryall_mcamo"}; // FIXME
+  backpack[] = {"B_Carryall_oli"};
   backpackItems[] = {};
-  magazines[] += {MAT_MAG};
+  magazines[] += {MAT_MAG2};
   items[] += {BASE_MEDICAL};
 };
 class soldier_AA_F: Fic_Soldier_Carbine {// SAM Gunner
-  SAM_GEAR("MNP_B_WD_CA", SAM_MAG)
+  SAM_GEAR("B_Carryall_oli", SAM_MAG)
   launchers[] = {SAM};
 };
 class Soldier_AAA_F: Fic_Spotter {// SAM Spotter/Ammo Bearer
-  SAM_GEAR("MNP_B_WD_CA", SAM_MAG)
+  SAM_GEAR("B_Carryall_oli", SAM_MAG2)
 };
 class support_Mort_F: Fic_Soldier_Carbine {// Mortar Gunner
   MORTAR_GEAR("I_Mortar_01_weapon_F")
@@ -165,7 +169,7 @@ class support_AMort_F: Fic_Spotter {// Assistant Mortar
   MORTAR_GEAR("I_Mortar_01_support_F")
 };
 class spotter_F: Fic_Spotter {// Spotter
-  headgear[] = {"MNP_Boonie_FIN","rhs_beanie_green"};
+  headgear[] = {"MNP_Boonie_FIN"};
   weapons[] = {SPOTTER};
   magazines[] = {SPOTTER_MAG,BASE_GRENADES};
   items[] += {RADIO_MR,"ACE_ATragMX","ACE_Kestrel4500","ACE_RangeCard"};
@@ -188,23 +192,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
-  backpackItems[] += {SIDE_KEY_IND,RADIO_LR};
+  backpackItems[] += {SIDE_KEY,RADIO_LR};
   linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {SIDE_KEY_IND,RADIO_LR};
+  backpackItems[] += {SIDE_KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class Soldier_repair_F: crew_F {// Repair Specialist
-  backpack[] = {"MNP_B_WD_CA"};
-  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY_IND};
+  backpack[] = {"B_Carryall_oli"};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
   linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_Eng: soldier_repair_F {
-  uniform[] = {"MNP_CombatUniform_ASA_GC", "MNP_CombatUniform_ASA_GC3","MNP_CombatUniform_ASA_GC2"};
   items[] += {BASE_ENG};
   backpackItems[] = {};
 };

--- a/Loadouts/ger_g36_fleck.hpp
+++ b/Loadouts/ger_g36_fleck.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "CUP_hgun_Glock17_tan"
 #define PISTOL_MAG "CUP_17Rnd_9x19_glock17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,15 +98,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -170,8 +170,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -182,19 +182,19 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   backpackItems[] = {};

--- a/Loadouts/ger_g36_tropen.hpp
+++ b/Loadouts/ger_g36_tropen.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "CUP_hgun_Glock17_tan"
 #define PISTOL_MAG "CUP_17Rnd_9x19_glock17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,15 +98,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -170,8 +170,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -182,19 +182,19 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   backpackItems[] = {};

--- a/Loadouts/ger_g38_fleck.hpp
+++ b/Loadouts/ger_g38_fleck.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "CUP_hgun_Glock17_tan"
 #define PISTOL_MAG "CUP_17Rnd_9x19_glock17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,15 +98,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -170,8 +170,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -182,19 +182,19 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   backpackItems[] = {};

--- a/Loadouts/ger_g38_tropen.hpp
+++ b/Loadouts/ger_g38_tropen.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "CUP_hgun_Glock17_tan"
 #define PISTOL_MAG "CUP_17Rnd_9x19_glock17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,15 +98,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -170,8 +170,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -182,19 +182,19 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   backpackItems[] = {};

--- a/Loadouts/indy_gear.hpp
+++ b/Loadouts/indy_gear.hpp
@@ -1,6 +1,6 @@
 #include "undef_side_gear.hpp"  // Reset defines
 
-#define SIDE_KEY "ACE_SIDE_KEY_indp"
+#define SIDE_KEY "ACE_key_indp"
 #define SIDE_CHEM_LIGHT "Chemlight_green:2"
 #define SIDE_UAV_BACKPACK "I_UAV_01_backpack_F"
 #define SIDE_UAV_TERMINAL "I_uavterminal"

--- a/Loadouts/indy_gear.hpp
+++ b/Loadouts/indy_gear.hpp
@@ -1,6 +1,6 @@
 #include "undef_side_gear.hpp"  // Reset defines
 
-#define KEY "ACE_key_indp"
-#define CHEM_LIGHT "Chemlight_green:2"
-#define UAV_BACKPACK "I_UAV_01_backpack_F"
-#define UAV_TERMINAL "I_uavterminal"
+#define SIDE_KEY "ACE_SIDE_KEY_indp"
+#define SIDE_CHEM_LIGHT "Chemlight_green:2"
+#define SIDE_UAV_BACKPACK "I_UAV_01_backpack_F"
+#define SIDE_UAV_TERMINAL "I_uavterminal"

--- a/Loadouts/msv_csat_qbz95_ghex_apex.hpp
+++ b/Loadouts/msv_csat_qbz95_ghex_apex.hpp
@@ -46,12 +46,12 @@
 #define PISTOL "hgun_Rook40_F"
 #define PISTOL_MAG "16Rnd_9x21_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY,"H_HelmetLeaderO_ghex_F"
-#define BASE_LINKED COMMON_LINKED,"O_NVGoggles_ghex_F"
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY,"H_HelmetLeaderO_ghex_F"
+#define LINKED BASE_LINKED,"O_NVGoggles_ghex_F"
+#define LEADER_LINKED BASE_LEADER_LINKED
 #define MSV_EXP "DemoCharge_Remote_Mag:2"
 
 class Car {
@@ -80,8 +80,8 @@ class potato_msv_rifleman { // rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -89,14 +89,14 @@ class potato_msv_sr: potato_msv_rifleman {// FTL
   vest[] = {"V_HarnessOGL_ghex_F"};
   weapons[] = {GLRIFLE};
   magazines[] = {GLRIFLE_MAG,GLRIFLE_MAG_HE,GLRIFLE_MAG_SMOKE,LEADER_GRENADES};
-  items[] += {COMMON_LEADER_TOOLS,KEY};
+  items[] += {BASE_LEADER_TOOLS,SIDE_KEY};
   linkedItems[] += {LEADER_LINKED,BINOS};
 };
 class potato_msv_sl: potato_msv_sr { // SL
   headgear[] = {"H_HelmetCrew_O_ghex_F"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class potato_msv_plt: potato_msv_sl { // PLT
@@ -195,8 +195,8 @@ class potato_msv_pilot {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
   attachments[] = {};
 };
 class potato_msv_cc: potato_msv_pilot {// Crew Chief
@@ -205,7 +205,7 @@ class potato_msv_cc: potato_msv_pilot {// Crew Chief
 class fic_vehicle_crewman: potato_msv_rifleman {// Vehicle crew base
   headgear[] = {"H_HelmetCrew_O_ghex_F"};
   magazines[] = {RIFLE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY};
+  backpackItems[] = {SIDE_KEY};
   linkedItems[] += {LEADER_LINKED};
   items[] += {BASE_MEDICAL};
 };
@@ -224,10 +224,10 @@ class potato_msv_eng: potato_msv_rifleman {// Demoman
   items[] += {BASE_ENG,BASE_MEDICAL};
   backpackItems[] = {"Toolkit"};
   magazines[] += {MSV_EXP};
-  linkedItems[] = {BASE_LINKED};
+  linkedItems[] = {LINKED};
 };
 class potato_msv_engl: potato_msv_eng {// Demoman Leader
-  backpackItems[] += {RADIO_MR,KEY};
+  backpackItems[] += {RADIO_MR,SIDE_KEY};
   linkedItems[] += {LEADER_LINKED};
 };
 class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman
@@ -238,17 +238,17 @@ class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman
   weapons[] = {RECON_RIFLE};
   handguns[] = {PISTOL};
   magazines[] = {RECON_RIFLE_MAGS,BASE_GRENADES,PISTOL_MAG};
-  linkedItems[] = {COMMON_LINKED};
+  linkedItems[] = {BASE_LINKED};
   attachments[] = {RECON_RIFLE_ATTACHMENTS};
   handgunAttachments[] = {"muzzle_snds_L"};
   opticChoices[] = {};
 };
 class potato_msv_sf_ftl: potato_msv_sf_rifleman {// Recon Senior Rifleman
-  items[] += {COMMON_LEADER_TOOLS,KEY}; // Avoid using leader tools because it adds double headgear (viper is not mechanized)
+  items[] += {BASE_LEADER_TOOLS,SIDE_KEY}; // Avoid using leader tools because it adds double headgear (viper is not mechanized)
   linkedItems[] += {LEADER_LINKED,BINOS};
 };
 class potato_msv_sf_sl: potato_msv_sf_ftl {// Recon Squad Leader
-  linkedItems[] = {COMMON_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class potato_msv_sf_g: potato_msv_sf_rifleman {//Recon Grenadier WARNING: REDUCED ROCKETS FOR VIPER TEAM

--- a/Loadouts/msv_csat_sama_hex.hpp
+++ b/Loadouts/msv_csat_sama_hex.hpp
@@ -50,12 +50,12 @@
 #define PISTOL "hgun_Rook40_F"
 #define PISTOL_MAG "16Rnd_9x21_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY,"H_HelmetLeaderO_ocamo"
-#define BASE_LINKED COMMON_LINKED,"NVGoggles"
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY,"H_HelmetLeaderO_ocamo"
+#define LINKED BASE_LINKED,"NVGoggles"
+#define LEADER_LINKED BASE_LEADER_LINKED
 #define MSV_EXP "DemoCharge_Remote_Mag:2"
 
 class Car {
@@ -84,8 +84,8 @@ class potato_msv_rifleman { // rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -97,14 +97,14 @@ class potato_msv_sr: potato_msv_rifleman {// FTL
   headgear[] = {"H_HelmetLeaderO_ocamo"};
   weapons[] = {GLRIFLE};
   magazines[] = {GLRIFLE_MAG,GLRIFLE_MAG_HE,GLRIFLE_MAG_SMOKE,LEADER_GRENADES};
-  items[] += {COMMON_LEADER_TOOLS,KEY};
+  items[] += {BASE_LEADER_TOOLS,SIDE_KEY};
   linkedItems[] += {LEADER_LINKED,BINOS};
 };
 class potato_msv_sl: potato_msv_sr { // SL
   headgear[] = {"H_HelmetCrew_O"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class potato_msv_plt: potato_msv_sl { // PLT
@@ -204,8 +204,8 @@ class potato_msv_pilot {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class potato_msv_cc: potato_msv_pilot {// Crew Chief
   headgear[] = {"H_CrewHelmetHeli_O"};
@@ -213,8 +213,8 @@ class potato_msv_cc: potato_msv_pilot {// Crew Chief
 class fic_vehicle_crewman: potato_msv_rifleman {// Vehicle crew base
   headgear[] = {"H_HelmetCrew_O"};
   magazines[] = {RIFLE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY};
-  linkedItems[] += {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {SIDE_KEY};
+  linkedItems[] += {LINKED,LEADER_LINKED};
   items[] += {BASE_MEDICAL};
 };
 class potato_msv_vicc: fic_vehicle_crewman {// Vehicle Crewman (non-repair)
@@ -232,26 +232,26 @@ class potato_msv_eng: potato_msv_rifleman {// Demoman
   items[] += {BASE_ENG,BASE_MEDICAL};
   backpackItems[] = {"Toolkit"};
   magazines[] += {MSV_EXP};
-  linkedItems[] = {BASE_LINKED};
+  linkedItems[] = {LINKED};
 };
 class potato_msv_engl: potato_msv_eng {// Demoman Leader
-  backpackItems[] += {RADIO_MR,KEY};
+  backpackItems[] += {RADIO_MR,SIDE_KEY};
   linkedItems[] += {LEADER_LINKED};
 };
 class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman
   weapons[] = {RIFLE};
   handguns[] = {PISTOL};
   magazines[] = {RIFLE_MAG,BASE_GRENADES,PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED};
+  linkedItems[] = {LINKED};
   attachments[] = {RECON_RIFLE_ATTACHMENTS};
   handgunAttachments[] = {"muzzle_snds_L"};
 };
 class potato_msv_sf_ftl: potato_msv_sf_rifleman {// Recon Senior Rifleman
-  items[] += {COMMON_LEADER_TOOLS,KEY}; // Avoid using leader linked because it adds double headgear
+  items[] += {BASE_LEADER_TOOLS,SIDE_KEY}; // Avoid using leader linked because it adds double headgear
   linkedItems[] += {LEADER_LINKED,BINOS};
 };
 class potato_msv_sf_sl: potato_msv_sf_ftl {// Recon Squad Leader
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class potato_msv_sf_g: potato_msv_sf_rifleman {

--- a/Loadouts/msv_csat_sama_uhex.hpp
+++ b/Loadouts/msv_csat_sama_uhex.hpp
@@ -50,12 +50,12 @@
 #define PISTOL "hgun_Rook40_F"
 #define PISTOL_MAG "16Rnd_9x21_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY,"H_HelmetLeaderO_oucamo"
-#define BASE_LINKED COMMON_LINKED,"NVGoggles_OPFOR"
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY,"H_HelmetLeaderO_oucamo"
+#define LINKED BASE_LINKED,"NVGoggles_OPFOR"
+#define LEADER_LINKED BASE_LEADER_LINKED
 #define MSV_EXP "DemoCharge_Remote_Mag:2"
 
 class Car {
@@ -84,8 +84,8 @@ class potato_msv_rifleman { // rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -97,14 +97,14 @@ class potato_msv_sr: potato_msv_rifleman {// FTL
   headgear[] = {"H_HelmetLeaderO_oucamo"};
   weapons[] = {GLRIFLE};
   magazines[] = {GLRIFLE_MAG,GLRIFLE_MAG_HE,GLRIFLE_MAG_SMOKE,LEADER_GRENADES};
-  items[] += {COMMON_LEADER_TOOLS,KEY};
+  items[] += {BASE_LEADER_TOOLS,SIDE_KEY};
   linkedItems[] += {LEADER_LINKED,BINOS};
 };
 class potato_msv_sl: potato_msv_sr { // SL
   headgear[] = {"H_HelmetCrew_O"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class potato_msv_plt: potato_msv_sl { // PLT
@@ -199,8 +199,8 @@ class potato_msv_pilot {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class potato_msv_cc: potato_msv_pilot {// Crew Chief
   headgear[] = {"H_CrewHelmetHeli_O"};
@@ -208,8 +208,8 @@ class potato_msv_cc: potato_msv_pilot {// Crew Chief
 class fic_vehicle_crewman: potato_msv_rifleman {// Vehicle crew base
   headgear[] = {"H_HelmetCrew_O"};
   magazines[] = {RIFLE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY};
-  linkedItems[] += {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {SIDE_KEY};
+  linkedItems[] += {LINKED,LEADER_LINKED};
   items[] += {BASE_MEDICAL};
 };
 class potato_msv_vicc: fic_vehicle_crewman {// Vehicle Crewman (non-repair)
@@ -227,26 +227,26 @@ class potato_msv_eng: potato_msv_rifleman {// Demoman
   items[] += {BASE_ENG,BASE_MEDICAL};
   backpackItems[] = {"Toolkit"};
   magazines[] += {MSV_EXP};
-  linkedItems[] = {BASE_LINKED};
+  linkedItems[] = {LINKED};
 };
 class potato_msv_engl: potato_msv_eng {// Demoman Leader
-  backpackItems[] += {RADIO_MR,KEY};
+  backpackItems[] += {RADIO_MR,SIDE_KEY};
   linkedItems[] += {LEADER_LINKED};
 };
 class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman
   weapons[] = {RIFLE};
   handguns[] = {PISTOL};
   magazines[] = {RIFLE_MAG,BASE_GRENADES,PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED};
+  linkedItems[] = {LINKED};
   attachments[] = {RECON_RIFLE_ATTACHMENTS};
   handgunAttachments[] = {"muzzle_snds_L"};
 };
 class potato_msv_sf_ftl: potato_msv_sf_rifleman {// Recon Senior Rifleman
-  items[] += {COMMON_LEADER_TOOLS,KEY}; // Avoid using leader tools because it adds double headgear
+  items[] += {BASE_LEADER_TOOLS,SIDE_KEY}; // Avoid using leader tools because it adds double headgear
   linkedItems[] += {LEADER_LINKED,BINOS};
 };
 class potato_msv_sf_sl: potato_msv_sf_ftl {// Recon Squad Leader
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class potato_msv_sf_g: potato_msv_sf_rifleman {

--- a/Loadouts/msv_ru_ak74_emr.hpp
+++ b/Loadouts/msv_ru_ak74_emr.hpp
@@ -46,12 +46,12 @@
 #define PISTOL "rhs_weap_pya"
 #define PISTOL_MAG "rhs_mag_9x19_17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED,"rhs_1PN138"
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED,"rhs_1PN138"
+#define LEADER_LINKED BASE_LEADER_LINKED
 #define MSV_EXP "DemoCharge_Remote_Mag:2"
 
 class Car {
@@ -80,8 +80,8 @@ class potato_msv_rifleman { // rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -97,7 +97,7 @@ class potato_msv_sl: potato_msv_sr { // SL
   backpack[] = {"B_FieldPack_oli"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR,"rhs_6b27m_digi"};
 };
 class potato_msv_plt: potato_msv_sl { // PLT
@@ -198,16 +198,16 @@ class potato_msv_pilot {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,COMMON_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {COMMON_LINKED,LEADER_LINKED,"rhsusf_ANPVS_15"}; // Theres no double tube NVGs for pilots in RHS yet
+  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {BASE_LINKED,LEADER_LINKED,"rhsusf_ANPVS_15"}; // Theres no double tube NVGs for pilots in RHS yet
   attachments[] = {"rhs_acc_dtk"};
 };
 class potato_msv_cc: potato_msv_pilot {};// Crew Chief
 class fic_vehicle_crewman: potato_msv_rifleman {// Vehicle crew base
   headgear[] = {"rhs_tsh4","rhs_tsh4_bala","rhs_tsh4_ess","rhs_tsh4_ess_bala"};
   magazines[] = {RIFLE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY};
-  linkedItems[] += {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {SIDE_KEY};
+  linkedItems[] += {LINKED,LEADER_LINKED};
   items[] += {BASE_MEDICAL};
 };
 class potato_msv_vicc: fic_vehicle_crewman {// Vehicle Crewman (non-repair)
@@ -227,7 +227,7 @@ class potato_msv_eng: potato_msv_rifleman {// Demoman
   magazines[] += {MSV_EXP};
 };
 class potato_msv_engl: potato_msv_eng {// Demoman Leader
-  backpackItems[] += {RADIO_MR,KEY};
+  backpackItems[] += {RADIO_MR,SIDE_KEY};
   linkedItems[] += {LEADER_LINKED};
 };
 class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman
@@ -247,7 +247,7 @@ class potato_msv_sf_ftl: potato_msv_sf_rifleman {// Recon Senior Rifleman
   linkedItems[] += {LEADER_LINKED,BINOS};
 };
 class potato_msv_sf_sl: potato_msv_sf_ftl {// Recon Squad Leader
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR,"rhs_6b27m_digi"};
 };
 class potato_msv_sf_ar: potato_msv_sf_rifleman {// Recon AR

--- a/Loadouts/msv_ru_ak74_emrd.hpp
+++ b/Loadouts/msv_ru_ak74_emrd.hpp
@@ -54,12 +54,12 @@
 #define PISTOL "rhs_weap_pya"
 #define PISTOL_MAG "rhs_mag_9x19_17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED,"rhs_1PN138"
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED,"rhs_1PN138"
+#define LEADER_LINKED BASE_LEADER_LINKED
 #define MSV_EXP "DemoCharge_Remote_Mag:2"
 
 class Car {
@@ -88,8 +88,8 @@ class potato_msv_rifleman { // rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -105,7 +105,7 @@ class potato_msv_sl: potato_msv_sr { // SL
   backpack[] = {"B_FieldPack_oli"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR,"rhs_6b27m_digi"};
 };
 class potato_msv_plt: potato_msv_sl { // PLT
@@ -206,16 +206,16 @@ class potato_msv_pilot {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,COMMON_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {COMMON_LINKED,LEADER_LINKED,"rhsusf_ANPVS_15"}; // Theres no double tube NVGs for pilots in RHS yet
+  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {BASE_LINKED,LEADER_LINKED,"rhsusf_ANPVS_15"}; // Theres no double tube NVGs for pilots in RHS yet
   attachments[] = {"rhs_acc_dtk"};
 };
 class potato_msv_cc: potato_msv_pilot {};// Crew Chief
 class fic_vehicle_crewman: potato_msv_rifleman {// Vehicle crew base
   headgear[] = {"rhs_tsh4","rhs_tsh4_bala","rhs_tsh4_ess","rhs_tsh4_ess_bala"};
   magazines[] = {RIFLE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY};
-  linkedItems[] += {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {SIDE_KEY};
+  linkedItems[] += {LINKED,LEADER_LINKED};
   items[] += {BASE_MEDICAL};
 };
 class potato_msv_vicc: fic_vehicle_crewman {// Vehicle Crewman (non-repair)
@@ -235,7 +235,7 @@ class potato_msv_eng: potato_msv_rifleman {// Demoman
   magazines[] += {MSV_EXP};
 };
 class potato_msv_engl: potato_msv_eng {// Demoman Leader
-  backpackItems[] += {RADIO_MR,KEY};
+  backpackItems[] += {RADIO_MR,SIDE_KEY};
   linkedItems[] += {LEADER_LINKED};
 };
 class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman
@@ -255,7 +255,7 @@ class potato_msv_sf_ftl: potato_msv_sf_rifleman {// Recon Senior Rifleman
   linkedItems[] += {LEADER_LINKED,BINOS};
 };
 class potato_msv_sf_sl: potato_msv_sf_ftl {// Recon Squad Leader
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR,"rhs_6b27m_digi"};
 };
 class potato_msv_sf_ar: potato_msv_sf_rifleman {// Recon AR

--- a/Loadouts/msv_ru_ak74_flora.hpp
+++ b/Loadouts/msv_ru_ak74_flora.hpp
@@ -46,12 +46,12 @@
 #define PISTOL "rhs_weap_pya"
 #define PISTOL_MAG "rhs_mag_9x19_17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED,"rhs_1PN138"
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED,"rhs_1PN138"
+#define LEADER_LINKED BASE_LEADER_LINKED
 #define MSV_EXP "DemoCharge_Remote_Mag:2"
 
 class Car {
@@ -80,8 +80,8 @@ class potato_msv_rifleman { // rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -97,7 +97,7 @@ class potato_msv_sl: potato_msv_sr { // SL
   backpack[] = {"B_FieldPack_oli"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR,"rhs_6b27m"};
 };
 class potato_msv_plt: potato_msv_sl { // PLT
@@ -198,16 +198,16 @@ class potato_msv_pilot {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,COMMON_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {COMMON_LINKED,LEADER_LINKED,"rhsusf_ANPVS_15"}; // Theres no double tube NVGs for pilots in RHS yet
+  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {BASE_LINKED,LEADER_LINKED,"rhsusf_ANPVS_15"}; // Theres no double tube NVGs for pilots in RHS yet
   attachments[] = {"rhs_acc_dtk"};
 };
 class potato_msv_cc: potato_msv_pilot {};// Crew Chief
 class fic_vehicle_crewman: potato_msv_rifleman {// Vehicle crew base
   headgear[] = {"rhs_tsh4","rhs_tsh4_bala","rhs_tsh4_ess","rhs_tsh4_ess_bala"};
   magazines[] = {RIFLE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY};
-  linkedItems[] += {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {SIDE_KEY};
+  linkedItems[] += {LINKED,LEADER_LINKED};
   items[] += {BASE_MEDICAL};
 };
 class potato_msv_vicc: fic_vehicle_crewman {// Vehicle Crewman (non-repair)
@@ -227,7 +227,7 @@ class potato_msv_eng: potato_msv_rifleman {// Demoman
   magazines[] += {MSV_EXP};
 };
 class potato_msv_engl: potato_msv_eng {// Demoman Leader
-  backpackItems[] += {RADIO_MR,KEY};
+  backpackItems[] += {RADIO_MR,SIDE_KEY};
   linkedItems[] += {LEADER_LINKED};
 };
 class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman
@@ -247,7 +247,7 @@ class potato_msv_sf_ftl: potato_msv_sf_rifleman {// Recon Senior Rifleman
   linkedItems[] += {LEADER_LINKED,BINOS};
 };
 class potato_msv_sf_sl: potato_msv_sf_ftl {// Recon Squad Leader
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR,"rhs_6b27m_digi"};
 };
 class potato_msv_sf_ar: potato_msv_sf_rifleman {// Recon AR

--- a/Loadouts/msv_sov_akm_ttsko.hpp
+++ b/Loadouts/msv_sov_akm_ttsko.hpp
@@ -49,12 +49,12 @@
 #define PISTOL "rhs_weap_pya"
 #define PISTOL_MAG "rhs_mag_9x19_17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED,"rhs_1PN138"
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED,"rhs_1PN138"
+#define LEADER_LINKED BASE_LEADER_LINKED
 #define MSV_EXP "DemoCharge_Remote_Mag:2"
 
 class Car {
@@ -83,8 +83,8 @@ class potato_msv_rifleman { // rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS}; // rhs_1PN138 russian single tube NVG
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS}; // rhs_1PN138 russian single tube NVG
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
 };
 class potato_msv_sr: potato_msv_rifleman {// FTL
@@ -99,7 +99,7 @@ class potato_msv_sl: potato_msv_sr { // SL
   backpack[] = {"B_FieldPack_khk"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR,"rhsgref_6b27m_ttsko_forest"};
 };
 class potato_msv_plt: potato_msv_sl { // PLT
@@ -200,16 +200,16 @@ class potato_msv_pilot {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,COMMON_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {COMMON_LINKED,LEADER_LINKED,"rhsusf_ANPVS_15"}; // Theres no double tube NVGs for pilots in RHS yet
+  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {BASE_LINKED,LEADER_LINKED,"rhsusf_ANPVS_15"}; // Theres no double tube NVGs for pilots in RHS yet
   attachments[] = {"rhs_acc_dtk"};
 };
 class potato_msv_cc: potato_msv_pilot {};// Crew Chief
 class fic_vehicle_crewman: potato_msv_rifleman {// Vehicle crew base
   headgear[] = {"rhs_tsh4","rhs_tsh4_bala","rhs_tsh4_ess","rhs_tsh4_ess_bala"};
   magazines[] = {RIFLE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY};
-  linkedItems[] += {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {SIDE_KEY};
+  linkedItems[] += {LINKED,LEADER_LINKED};
   items[] += {BASE_MEDICAL};
 };
 class potato_msv_vicc: fic_vehicle_crewman {// Vehicle Crewman (non-repair)
@@ -229,7 +229,7 @@ class potato_msv_eng: potato_msv_rifleman {// Demoman
   magazines[] += {MSV_EXP};
 };
 class potato_msv_engl: potato_msv_eng {// Demoman Leader
-  backpackItems[] += {RADIO_MR,KEY};
+  backpackItems[] += {RADIO_MR,SIDE_KEY};
   linkedItems[] += {LEADER_LINKED};
 };
 class potato_msv_sf_rifleman: potato_msv_rifleman {// Recon Rifleman
@@ -249,7 +249,7 @@ class potato_msv_sf_ftl: potato_msv_sf_rifleman {// Recon Senior Rifleman
   linkedItems[] += {LEADER_LINKED,BINOS};
 };
 class potato_msv_sf_sl: potato_msv_sf_ftl {// Recon Squad Leader
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR,"rhs_6b27m_digi"};
 };
 class potato_msv_sf_ar: potato_msv_sf_rifleman {// Recon AR

--- a/Loadouts/reb_ak47_desert.hpp
+++ b/Loadouts/reb_ak47_desert.hpp
@@ -49,12 +49,12 @@
 #define PISTOL "rhs_weap_makarov_pmm"
 #define PISTOL_MAG "rhs_mag_9x18_12_57N181S:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -81,8 +81,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
 };
 class Fic_Soldier_Carbine: Soldier_F {// carbine-man
@@ -100,7 +100,7 @@ class Soldier_SL_F: Soldier_TL_F {// SL
   backpack[] = {"B_Kitbag_rgr"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] += {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] += {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
@@ -108,8 +108,8 @@ class officer_F: Soldier_SL_F {// CO and DC
 };
 class soldier_UAV_F: Soldier_F {
   vest[] = {"MNP_Vest_UKR_B","MNP_Vest_6co_A","MNP_Vest_6co_B"};
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -187,8 +187,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -198,22 +198,22 @@ class Helipilot_F {// Pilot
   backpack[] = {"B_AssaultPack_rgr"};
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
   backpackItems[] += {RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"MNP_Vest_UKR_B","MNP_Vest_6co_A","MNP_Vest_6co_B"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class Soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_khk"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_Eng: soldier_repair_F {
   items[] += {BASE_ENG};

--- a/Loadouts/ru_ak74_desert.hpp
+++ b/Loadouts/ru_ak74_desert.hpp
@@ -49,12 +49,12 @@
 #define PISTOL "rhs_weap_pya"
 #define PISTOL_MAG "rhs_mag_9x19_17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -81,8 +81,8 @@ class Soldier_F { // rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -101,15 +101,15 @@ class soldier_SL_F: Soldier_TL_F { // SL
   backpack[] = {"B_Kitbag_cbr"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F { // CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class soldier_GL_F: Soldier_TL_F {}; // GP Dude
 class Soldier_AR_F: Soldier_F {// AR
@@ -182,8 +182,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -194,8 +194,8 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
   attachments[] = {"rhs_acc_dtk"};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
@@ -203,13 +203,13 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   headgear[] = {"rhs_tsh4","rhs_tsh4_bala"};
   backpack[] = {"rhs_assault_umbts_engineer_empty"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {KEY,RADIO_LR};
+  backpackItems[] += {SIDE_KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"rhs_6b27m_green","rhs_6b27m_green_bala"};

--- a/Loadouts/ru_ak74_emr.hpp
+++ b/Loadouts/ru_ak74_emr.hpp
@@ -49,12 +49,12 @@
 #define PISTOL "rhs_weap_pya"
 #define PISTOL_MAG "rhs_mag_9x19_17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -81,8 +81,8 @@ class Soldier_F { // rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -101,15 +101,15 @@ class soldier_SL_F: Soldier_TL_F { // SL
   backpack[] = {"B_Kitbag_rgr"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F { // CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class soldier_GL_F: Soldier_TL_F {}; // GP Dude
 class Soldier_AR_F: Soldier_F {// AR
@@ -181,8 +181,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -193,8 +193,8 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
   attachments[] = {"rhs_acc_dtk"};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
@@ -202,13 +202,13 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   headgear[] = {"rhs_tsh4","rhs_tsh4_bala"};
   backpack[] = {"rhs_assault_umbts_engineer_empty"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {KEY,RADIO_LR};
+  backpackItems[] += {SIDE_KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"rhs_6b47","rhs_6b47_bala"};

--- a/Loadouts/ru_ak74_floral.hpp
+++ b/Loadouts/ru_ak74_floral.hpp
@@ -49,12 +49,12 @@
 #define PISTOL "rhs_weap_pya"
 #define PISTOL_MAG "rhs_mag_9x19_17:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -81,8 +81,8 @@ class Soldier_F { // rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -101,15 +101,15 @@ class soldier_SL_F: Soldier_TL_F { // SL
   backpack[] = {"B_Kitbag_rgr"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F { // CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class soldier_GL_F: Soldier_TL_F {}; // GP Dude
 class Soldier_AR_F: Soldier_F {// AR
@@ -181,8 +181,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -193,8 +193,8 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
   attachments[] = {"rhs_acc_dtk"};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
@@ -202,13 +202,13 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   headgear[] = {"rhs_tsh4","rhs_tsh4_bala"};
   backpack[] = {"rhs_assault_umbts_engineer_empty"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {KEY,RADIO_LR};
+  backpackItems[] += {SIDE_KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"rhs_6b26","rhs_6b26_bala"};

--- a/Loadouts/ukr_ak74_ddpm.hpp
+++ b/Loadouts/ukr_ak74_ddpm.hpp
@@ -50,12 +50,12 @@
 #define PISTOL "rhs_weap_makarov_pmm"
 #define PISTOL_MAG "rhs_mag_9x18_12_57N181S:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -82,8 +82,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -101,15 +101,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] += {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] += {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -180,8 +180,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -191,21 +191,21 @@ class Helipilot_F {// Pilot
   backpack[] = {"B_AssaultPack_rgr"};
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
   backpackItems[] += {RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {KEY,RADIO_LR};
+  backpackItems[] += {SIDE_KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class Soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_khk"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_Eng: soldier_repair_F {
   items[] += {BASE_ENG};

--- a/Loadouts/ukr_ak74_ttsko.hpp
+++ b/Loadouts/ukr_ak74_ttsko.hpp
@@ -50,12 +50,12 @@
 #define PISTOL "rhs_weap_makarov_pmm"
 #define PISTOL_MAG "rhs_mag_9x18_12_57N181S:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -82,8 +82,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -101,15 +101,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] += {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] += {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -181,8 +181,8 @@ class sniper_F: spotter_F {// Sniper
   headgear[] = {"MNP_Helmet_PAGST_UKR","MNP_Helmet_PAGST_UKR","MNP_Helmet_PAGST_UKR","MNP_MC_UKR"};
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -192,21 +192,21 @@ class Helipilot_F {// Pilot
   backpack[] = {"B_AssaultPack_rgr"};
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
   backpackItems[] += {RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] += {KEY,RADIO_LR};
+  backpackItems[] += {SIDE_KEY,RADIO_LR};
   linkedItems[] += {LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class Soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"MNP_B_WD_CA"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_Eng: soldier_repair_F {
   uniform[] = {"MNP_CombatUniform_ASA_GC", "MNP_CombatUniform_ASA_GC3","MNP_CombatUniform_ASA_GC2"};

--- a/Loadouts/undef.hpp
+++ b/Loadouts/undef.hpp
@@ -112,14 +112,14 @@
 #ifdef LEADER_GRENADES
   #undef LEADER_GRENADES
 #endif
-#ifdef BASE_TOOLS
-  #undef BASE_TOOLS
+#ifdef TOOLS
+  #undef TOOLS
 #endif
 #ifdef LEADER_TOOLS
   #undef LEADER_TOOLS
 #endif
-#ifdef BASE_LINKED
-  #undef BASE_LINKED
+#ifdef LINKED
+  #undef LINKED
 #endif
 #ifdef LEADER_LINKED
   #undef LEADER_LINKED

--- a/Loadouts/undef_side_gear.hpp
+++ b/Loadouts/undef_side_gear.hpp
@@ -1,13 +1,13 @@
 // Reset side defines
-#ifdef KEY
-  #undef KEY
+#ifdef SIDE_KEY
+  #undef SIDE_KEY
 #endif
-#ifdef CHEM_LIGHT
-  #undef CHEM_LIGHT
+#ifdef SIDE_CHEM_LIGHT
+  #undef SIDE_CHEM_LIGHT
 #endif
-#ifdef UAV_BACKPACK
-  #undef UAV_BACKPACK
+#ifdef SIDE_UAV_BACKPACK
+  #undef SIDE_UAV_BACKPACK
 #endif
-#ifdef UAV_TERMINAL
-  #undef UAV_TERMINAL
+#ifdef SIDE_UAV_TERMINAL
+  #undef SIDE_UAV_TERMINAL
 #endif

--- a/Loadouts/us_hk416_marpatd.hpp
+++ b/Loadouts/us_hk416_marpatd.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "rhsusf_weap_m9"
 #define PISTOL_MAG "rhsusf_mag_15Rnd_9x19_JHP:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,15 +98,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -173,8 +173,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -185,20 +185,20 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_cbr"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"CUP_H_USMC_MICH2000_DES"};

--- a/Loadouts/us_hk416_marpatw.hpp
+++ b/Loadouts/us_hk416_marpatw.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "rhsusf_weap_m9"
 #define PISTOL_MAG "rhsusf_mag_15Rnd_9x19_JHP:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -98,15 +98,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -173,8 +173,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -185,20 +185,20 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_khk"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"CUP_H_USMC_MICH2000_WDL"};

--- a/Loadouts/us_hk416_mtp_apex.hpp
+++ b/Loadouts/us_hk416_mtp_apex.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "hgun_Pistol_heavy_01_F"
 #define PISTOL_MAG "11Rnd_45ACP_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -100,15 +100,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -176,8 +176,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -188,8 +188,8 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
@@ -197,14 +197,14 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_khk"};
   headgear[] = {"H_HelmetCrew_B"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_mcamo"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetSpecB_snakeskin"};

--- a/Loadouts/us_hk416_trop_apex.hpp
+++ b/Loadouts/us_hk416_trop_apex.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "hgun_Pistol_heavy_01_F"
 #define PISTOL_MAG "11Rnd_45ACP_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -100,15 +100,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -176,8 +176,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -188,22 +188,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_oli"};
   headgear[] = {"H_HelmetCrew_B"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_oli"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetB_tna_F"};

--- a/Loadouts/us_m16_m81.hpp
+++ b/Loadouts/us_m16_m81.hpp
@@ -47,12 +47,12 @@
 #define PISTOL "rhsusf_weap_m1911a1"
 #define PISTOL_MAG "rhsusf_mag_7x45acp_MHP:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -79,8 +79,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -97,15 +97,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -172,8 +172,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -184,20 +184,20 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"MNP_B_WD_CA"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"MNP_Helmet_USW"};

--- a/Loadouts/us_m4_ocp.hpp
+++ b/Loadouts/us_m4_ocp.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "rhsusf_weap_m1911a1"
 #define PISTOL_MAG "rhsusf_mag_7x45acp_MHP:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -101,15 +101,15 @@ class Soldier_SL_F: Soldier_TL_F {// SL
   headgear[] = {"rhsusf_ach_helmet_headset_ocp"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   vest[] = {"rhsusf_iotv_ocp_SAW"};
@@ -180,8 +180,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -192,8 +192,8 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
@@ -201,15 +201,15 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   headgear[] = {"rhsusf_cvc_green_ess"};
   backpack[] = {"B_Carryall_mcamo"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_mcamo"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
   vest[] = {"rhsusf_iotv_ocp_repair"};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"rhsusf_ach_helmet_ocp","rhsusf_ach_helmet_ESS_ocp"};

--- a/Loadouts/us_m4_ucp.hpp
+++ b/Loadouts/us_m4_ucp.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "rhsusf_weap_m1911a1"
 #define PISTOL_MAG "rhsusf_mag_7x45acp_MHP:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -101,15 +101,15 @@ class Soldier_SL_F: Soldier_TL_F {// SL
   headgear[] = {"rhsusf_ach_helmet_headset_ucp"};
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   vest[] = {"rhsusf_iotv_ucp_SAW"};
@@ -180,8 +180,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -192,8 +192,8 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
@@ -201,15 +201,15 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   headgear[] = {"rhsusf_cvc_green_ess"};
   backpack[] = {"B_Carryall_mcamo"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_mcamo"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
   vest[] = {"rhsusf_iotv_ucp_repair"};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"rhsusf_ach_helmet_ucp","rhsusf_ach_helmet_ESS_ucp"};

--- a/Loadouts/us_mx_mtp.hpp
+++ b/Loadouts/us_mx_mtp.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "hgun_Pistol_heavy_01_F"
 #define PISTOL_MAG "11Rnd_45ACP_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -100,15 +100,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -176,8 +176,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -188,8 +188,8 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
@@ -197,14 +197,14 @@ class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_khk"};
   headgear[] = {"H_HelmetCrew_B"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_mcamo"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetSpecB_snakeskin"};

--- a/Loadouts/us_mx_trop_apex.hpp
+++ b/Loadouts/us_mx_trop_apex.hpp
@@ -48,12 +48,12 @@
 #define PISTOL "hgun_Pistol_heavy_01_F"
 #define PISTOL_MAG "11Rnd_45ACP_Mag:3"
 // Grenades
-#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,CHEM_LIGHT
+#define LEADER_GRENADES BASE_FRAG,LEADER_SMOKES,SIDE_CHEM_LIGHT
 // Gear
-#define BASE_TOOLS COMMON_TOOLS
-#define LEADER_TOOLS COMMON_LEADER_TOOLS,KEY
-#define BASE_LINKED COMMON_LINKED
-#define LEADER_LINKED COMMON_LEADER_LINKED
+#define TOOLS BASE_TOOLS
+#define LEADER_TOOLS BASE_LEADER_TOOLS,SIDE_KEY
+#define LINKED BASE_LINKED
+#define LEADER_LINKED BASE_LEADER_LINKED
 
 class Car {
   TransportWeapons[] = {AT};
@@ -80,8 +80,8 @@ class Soldier_F {// rifleman
   backpackItems[] = {BASE_MEDICAL};
   weapons[] = {RIFLE};
   magazines[] = {RIFLE_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS};
+  linkedItems[] = {LINKED};
   attachments[] = {RIFLE_ATTACHMENTS};
   opticChoices[] = {ALT_OPTICS};
 };
@@ -100,15 +100,15 @@ class Soldier_TL_F: Soldier_F {// FTL
 class Soldier_SL_F: Soldier_TL_F {// SL
   handguns[] = {PISTOL};
   magazines[] += {PISTOL_MAG};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,RANGE_FINDER};
+  linkedItems[] = {LINKED,LEADER_LINKED,RANGE_FINDER};
   items[] += {RADIO_MR};
 };
 class officer_F: Soldier_SL_F {// CO and DC
   items[] += {RADIO_LR};
 };
 class soldier_UAV_F: Soldier_F {
-  backpack[] = {UAV_BACKPACK};
-  linkedItems[] += {UAV_TERMINAL};
+  backpack[] = {SIDE_UAV_BACKPACK};
+  linkedItems[] += {SIDE_UAV_TERMINAL};
 };
 class Soldier_AR_F: Soldier_F {// AR
   weapons[] = {AR};
@@ -176,8 +176,8 @@ class spotter_F: Fic_Spotter {// Spotter
 class sniper_F: spotter_F {// Sniper
   weapons[] = {SNIPER};
   magazines[] = {SNIPER_MAG,BASE_GRENADES};
-  items[] = {BASE_TOOLS,"ACE_RangeCard"};
-  linkedItems[] = {BASE_LINKED};
+  items[] = {TOOLS,"ACE_RangeCard"};
+  linkedItems[] = {LINKED};
   attachments[] = {SNIPER_ATTACHMENTS};
 };
 class Helipilot_F {// Pilot
@@ -188,22 +188,22 @@ class Helipilot_F {// Pilot
   weapons[] = {SMG};
   magazines[] = {SMG_MAG,CREW_GRENADES};
   backpackItems[] = {RADIO_LR};
-  items[] = {BASE_MEDICAL,BASE_TOOLS,LEADER_TOOLS,RADIO_MR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  items[] = {BASE_MEDICAL,TOOLS,LEADER_TOOLS,RADIO_MR};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class helicrew_F: Helipilot_F {}; // Pilot
 class crew_F: Fic_Soldier_Carbine {// Crew
   vest[] = {"V_Chestrig_oli"};
   headgear[] = {"H_HelmetCrew_B"};
   magazines[] = {CARBINE_MAG,CREW_GRENADES};
-  backpackItems[] = {KEY,RADIO_LR};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED,BINOS};
+  backpackItems[] = {SIDE_KEY,RADIO_LR};
+  linkedItems[] = {LINKED,LEADER_LINKED,BINOS};
   items[] += {BASE_MEDICAL};
 };
 class soldier_repair_F: crew_F {// Repair Specialist
   backpack[] = {"B_Carryall_oli"};
-  backpackItems[] = {"Toolkit",RADIO_MR,KEY};
-  linkedItems[] = {BASE_LINKED,LEADER_LINKED};
+  backpackItems[] = {"Toolkit",RADIO_MR,SIDE_KEY};
+  linkedItems[] = {LINKED,LEADER_LINKED};
 };
 class Fic_eng: soldier_repair_F {
   headgear[] = {"H_HelmetB_tna_F"};

--- a/Loadouts/west_gear.hpp
+++ b/Loadouts/west_gear.hpp
@@ -1,6 +1,6 @@
 #include "undef_side_gear.hpp" // Reset defines
 
-#define KEY "ACE_key_west"
-#define CHEM_LIGHT "Chemlight_blue:2"
-#define UAV_BACKPACK "B_UAV_01_backpack_F"
-#define UAV_TERMINAL "B_uavterminal"
+#define SIDE_KEY "ACE_SIDE_KEY_west"
+#define SIDE_CHEM_LIGHT "Chemlight_blue:2"
+#define SIDE_UAV_BACKPACK "B_UAV_01_backpack_F"
+#define SIDE_UAV_TERMINAL "B_uavterminal"

--- a/Loadouts/west_gear.hpp
+++ b/Loadouts/west_gear.hpp
@@ -1,6 +1,6 @@
 #include "undef_side_gear.hpp" // Reset defines
 
-#define SIDE_KEY "ACE_SIDE_KEY_west"
+#define SIDE_KEY "ACE_key_west"
 #define SIDE_CHEM_LIGHT "Chemlight_blue:2"
 #define SIDE_UAV_BACKPACK "B_UAV_01_backpack_F"
 #define SIDE_UAV_TERMINAL "B_uavterminal"


### PR DESCRIPTION
@zerithsmash / @PabstMirror can you sanity check the new macros? I wanted to make all the side/common defines more apparent.

Changes:
- Vectors with NVGs -> Vectors without NVGs
- Mix of common/base prefixed defines in common.hpp -> base prefixed defines in common.hpp
- Base prefixed defines in loadout implementations -> no base prefixed defines in loadout impls
- Add side prefix to side specific defines
- Add Finnish loadouts (MMG spotters will drop a mag, but the vest and uniform have super limited space, so we just have to make do)