### PR TITLE
Removes Earplugs from common load out

### DIFF
--- a/Loadouts/common.hpp
+++ b/Loadouts/common.hpp
@@ -8,7 +8,7 @@
 // GEAR
 #define BASE_MEDICAL "ACE_elasticBandage:4","ACE_packingBandage:2","ACE_tourniquet","ACE_morphine"
 #define MEDIC_MEDICAL "ACE_elasticBandage:25","ACE_packingBandage:15","ACE_epinephrine:10","ACE_salineIV:2","ACE_salineIV_500:4","ACE_salineIV_250:8","ACE_morphine:16","ACE_tourniquet:6"
-#define BASE_TOOLS RADIO_SR,"ACE_MapTools","ACE_IR_Strobe_item","ACE_earplugs"
+#define BASE_TOOLS RADIO_SR,"ACE_MapTools","ACE_IR_Strobe_item"
 #define BASE_LEADER_TOOLS "ACE_microDAGR","ACE_Flashlight_KSF1"
 #define BASE_LINKED "ItemMap","ItemCompass","ItemWatch"
 #define BASE_LEADER_LINKED "ItemGPS"


### PR DESCRIPTION
Does as the title says. 

Removes ACE_Earplugs from common.hpp