### PR TITLE
Loadouts - Add description for new supply box and vehicle loadout systems

### DIFF
--- a/CfgLoadouts.hpp
+++ b/CfgLoadouts.hpp
@@ -13,7 +13,7 @@ class CfgLoadouts {
   // -1. Clear and leave inventories empty empty
   //  0. Leave them to vanilla defaults
   //  1. Defined supplies are put into vehicle's inventory
-  //  2. Store supplies from vehicle inventory into ammo boxes in vehicle cargo
+  //  2. Store supplies from vehicle inventory into ammo boxes in vehicle ACE cargo
   //  3. Use ammo box definitions to create ammo boxes in vehicle's ACE cargo and clear inventory
   setVehicleLoadouts = -1;
 

--- a/CfgLoadouts.hpp
+++ b/CfgLoadouts.hpp
@@ -9,20 +9,46 @@ class CfgLoadouts {
   // Allow changeable optics on a global level, note: optic options obey allowMagnifiedOptics rules
   allowChangeableOptics = 1;
 
-  // Do Vehicle Loadouts
-  // (1 will run normaly, 0 will leave them to vanilla defaults, -1 will clear and leave empty)
+  // Vehicle Loadouts -- see "us_mx_mtp.hpp" for examples
+  // -1. Clear and leave inventories empty empty
+  //  0. Leave them to vanilla defaults
+  //  1. Defined supplies are put into vehicle's inventory
+  //  2. Store supplies from vehicle inventory into ammo boxes in vehicle cargo
+  //  3. Use ammo box definitions to create ammo boxes in vehicle's ACE cargo and clear inventory
   setVehicleLoadouts = -1;
 
   // Do Supply Box Loadouts
-  // (1 will run normaly, 0 will leave them to vanilla defaults, -1 will clear and leave empty)
+  // -1. Clear and leave inventories empty empty
+  //  0. Leave them to vanilla defaults
+  //  1. Defined supplies are put into box's inventory
+  //  2. Use ammo box definitions to create ammo boxes in box's ACE cargo and clear inventory
   setSupplyBoxLoadouts = 0;
   class SupplyBoxes {
-    /* Example:
-      class B_supplyCrate_F {
-        TransportWeapons[] = {"arifle_TRG20_F"};
+    /* Example: setSupplyBoxLoadouts = 1
+    class B_supplyCrate_F {
+      TransportWeapons[] = {"arifle_TRG20_F"};
+      TransportMagazines[] = {"30Rnd_556x45_Stanag_red:8","30Rnd_556x45_Stanag_Tracer_Red:2"};
+      TransportItems[] = {"ACRE_PRC148:10"};
+    };
+    */
+    /* Example: setSupplyBoxLoadouts = 2
+    class I_supplyCrate_F { // overarching box
+      addMarkingActions = 0; // 0 for none, 1 for single use of smoke/flare
+      boxCustomName = "Easy To Find Name";
+      boxSpace = 8; // ACE cargo space box will have
+      class Box_NATO_Ammo_F { // sub box
+        boxCount = 4; // number of boxes to create
+        boxCustomName = "Resupply Box";
+        TransportWeapons[] = {"arifle_TRG20_F:4"};
         TransportMagazines[] = {"30Rnd_556x45_Stanag_red:8","30Rnd_556x45_Stanag_Tracer_Red:2"};
-        TransportItems[] = {"ACRE_PRC148:10"};
+        TransportItems[] = {"ACE_elasticBandage:25","ACE_packingBandage:15","ACE_tourniquet:5","ACE_splint:5"};
       };
+    };
+    class B_supplyCrate_F { // falls back to work the same way as Mode 1 without defined sub-boxes
+      TransportWeapons[] = {"arifle_TRG20_F"};
+      TransportMagazines[] = {"30Rnd_556x45_Stanag_red:8","30Rnd_556x45_Stanag_Tracer_Red:2"};
+      TransportItems[] = {"ACRE_PRC148:10"};
+    };
     */
   };
 
@@ -38,9 +64,9 @@ class CfgLoadouts {
 
   // cleanup.bat will delete any loadouts not in active use (so make sure to include before running)
 
-  // Blufor/Indfor/Opfor folders are just for organization, they can be used with any faction 
+  // Blufor/Indfor/Opfor folders are just for organization, they can be used with any faction
   // e.g. Blufor\us_mx_mtp.hpp for potato_e is fine
-  
+
   // Loadouts can be either kept in the Loadouts\Blufor\ folders or moved up to Loadouts\
 
   // West factions

--- a/Loadouts/Blufor/us_mx_mtp.hpp
+++ b/Loadouts/Blufor/us_mx_mtp.hpp
@@ -66,6 +66,10 @@
 #define LEADER_LINKED BASE_LEADER_LINKED
 #define CARRYALL "B_Carryall_mcamo"
 
+//***** See setVehicleLoadouts on line 18 of the BWMF (pre-cleanup) *****//
+/// Example of setVehicleLoadouts = 1
+// Load weapons into vehicle inventory
+// Enabled by default
 class Car {
   TransportWeapons[] = {AT};
   TransportMagazines[] = {RIFLE_MAG,GLRIFLE_MAG,CARBINE_MAG,AR_MAG,AR_MAG,GLRIFLE_MAG_HE};
@@ -82,6 +86,41 @@ class Helicopter {
 };
 class Plane {};
 class Ship_F {};
+
+/// Example of setVehicleLoadouts = 2
+// Create ammo boxes out of items in vehicle inventory, greedy sort
+/*
+class B_Truck_01_ammo_F {
+  AmmoBox = "Box_NATO_Wps_F"; // type of box,
+  AmmoBoxCapacity = 200; // Box capacity in lbs
+  TransportWeapons[] = {AT};
+  TransportMagazines[] = {RIFLE_MAG,GLRIFLE_MAG,CARBINE_MAG,AR_MAG,AR_MAG,GLRIFLE_MAG_HE};
+  TransportItems[] = {BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL};
+};
+class Car { // this version uses the default box and default weight of 75 lbs
+  TransportWeapons[] = {AT};
+  TransportMagazines[] = {RIFLE_MAG,GLRIFLE_MAG,CARBINE_MAG,AR_MAG,AR_MAG,GLRIFLE_MAG_HE};
+  TransportItems[] = {BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL};
+};*/
+
+/// Example of setVehicleLoadoutse = 3
+// Creates filled ammo boxes in the vehicle's cargo, or default to mode 1 if no boxes are defined
+/*
+class Car {
+  minVehicleBoxSpace = 6; // set a minimum for the number of storage slots in a vehicles (used by wheels/tracks/fuel)
+  class Box_NATO_Ammo_F { // Add two boxes similiar to the resupply modes
+    boxCustomName = "Resupply Box"; // The name the boxes will have in inventory (enumerated if more than one)
+    boxCount = 2; // Add two of these boxes
+    // Box contents:
+    TransportWeapons[] = {AT};
+    TransportMagazines[] = {RIFLE_MAG,GLRIFLE_MAG,CARBINE_MAG,AR_MAG,AR_MAG,GLRIFLE_MAG_HE};
+    TransportItems[] = {BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL};
+  };
+};
+class Ship_F { // you can also fill the normal inventory if no boxes are defined:
+    TransportWeapons[] = {AT};
+    TransportMagazines[] = {RIFLE_MAG,GLRIFLE_MAG,CARBINE_MAG,AR_MAG,AR_MAG,GLRIFLE_MAG_HE};
+}; // See discord for more advanced applications */
 
 class rifleman {// rifleman
   uniform[] = {"U_B_CombatUniform_mcam"};

--- a/Loadouts/Blufor/us_mx_mtp.hpp
+++ b/Loadouts/Blufor/us_mx_mtp.hpp
@@ -103,7 +103,7 @@ class Car { // this version uses the default box and default weight of 75 lbs
   TransportItems[] = {BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL,BASE_MEDICAL};
 };*/
 
-/// Example of setVehicleLoadoutse = 3
+/// Example of setVehicleLoadouts = 3
 // Creates filled ammo boxes in the vehicle's cargo, or default to mode 1 if no boxes are defined
 /*
 class Car {


### PR DESCRIPTION
This PR adds description to `Loadouts.cfg` and examples to `us_mx_mtp.hpp` for the recently added vehicle and supply box loadout modes.

@TheCandianVendingMachine  - Let me know if you have any feedback on your mode's example and description.