### PR TITLE
Add PR template and Reset UUID to ""

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## PR Changes
+
+
+## PR Checklist
+- [ ] `addons[]` hasn't added non-potato or non-core game files
+- [ ] Author has not been set and is still `*** Insert author name here. ***`
+- [ ] SQM file is not binarized, and that `binarizationWanted = 1`
+- [ ] Radios and markers have not been set to `nil`.
+- [ ] Mission UUID  is `""`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,4 +6,4 @@
 - [ ] Author has not been set and is still `*** Insert author name here. ***`
 - [ ] SQM file is not binarized, and that `binarizationWanted = 1`
 - [ ] Radios and markers have not been set to `nil`.
-- [ ] Mission UUID  is `""`
+- [ ] Mission UUID (`potato_mission_uuid`) is set to `""`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,8 +2,9 @@
 
 
 ## PR Checklist
+- [ ] SQM file is not binarized
 - [ ] `addons[]` hasn't added non-potato or non-core game files
 - [ ] Author has not been set and is still `*** Insert author name here. ***`
-- [ ] SQM file is not binarized, and that `binarizationWanted = 1`
-- [ ] Radios and markers have not been set to `nil`.
+- [ ] `binarizationWanted = 1`
+- [ ] Radios and markers have not been set to `nil`
 - [ ] Mission UUID (`potato_mission_uuid`) is set to `""`

--- a/mission.sqm
+++ b/mission.sqm
@@ -317,7 +317,7 @@ class CustomAttributes
 				class data
 				{
 					singleType="STRING";
-					value="bd8d1fdb-efc2-414e-b646-eeea41270bbb";
+					value="";
 				};
 			};
 		};


### PR DESCRIPTION
## PR Changes
This PR adds a PR template/checklist and resets the UUID to `""`.

## PR Checklist
- [X] SQM file is not binarized
- [X] `addons[]` hasn't added non-potato or non-core game files
- [X] Author has not been set and is still `*** Insert author name here. ***`
- [X] `binarizationWanted = 1`
- [X] Radios and markers have not been set to `nil`
- [X] Mission UUID (`potato_mission_uuid`) is set to `""`
